### PR TITLE
chore: upgrade to polkadot v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1664,7 +1664,7 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "url",
 ]
 
@@ -1685,10 +1685,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1719,17 +1719,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1758,9 +1758,9 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-timestamp",
- "sp-trie 34.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1775,9 +1775,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -1794,14 +1794,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "tracing",
 ]
 
@@ -1819,14 +1819,14 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-crypto-hashing",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "tracing",
 ]
 
@@ -1851,7 +1851,7 @@ dependencies = [
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1884,12 +1884,12 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
@@ -1900,15 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2703d49952e0538c4d05fe1f1114e62741871693e862fc68ab56ae6b3b5230"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1924,28 +1924,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
- "staging-xcm 12.0.0",
- "trie-db 0.29.1",
+ "sp-trie",
+ "sp-version",
+ "staging-xcm",
+ "trie-db",
 ]
 
 [[package]]
@@ -1966,12 +1966,12 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be9d77e00ad1dbcf12dcd81c2758d651adf6e3072f3cb51c11d8739426f4cbb"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1982,14 +1982,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b7737eb5d81bcd79df114e711927ba19c2dbd312f245ae03b76d330abb3506d"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2001,9 +2001,9 @@ dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -2011,11 +2011,11 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -2025,11 +2025,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61fa5dad966e340092a4521b56b43dddce5bf466ddb07d9a01c534e63e4e0b7"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
+ "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2040,15 +2040,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad51d36ea156ef84d7e8ca5cea881867d3540e8dfdb8ea6b9d2b9190197a22a5"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
- "sp-trie 34.0.0",
- "staging-xcm 12.0.0",
+ "sp-trie",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2062,11 +2062,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ checksum = "e736734a6b4b0308d931756c30c3472fa5ec99a95be14f70567f25c97b3822cc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2089,12 +2089,12 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2105,18 +2105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee70eb2f55d20a965e3538fc96aac2801815af510b4460e8a5783f5197e0872"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
+ "frame-support",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -2137,11 +2137,11 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -2157,9 +2157,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -2178,7 +2178,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 12.0.0",
+ "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2196,11 +2196,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2231,14 +2231,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-version 34.0.0",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2255,10 +2255,10 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -3147,50 +3147,24 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
-dependencies = [
- "frame-support 32.0.0",
- "frame-support-procedural 27.0.0",
- "frame-system 32.0.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 30.0.0",
- "sp-application-crypto 34.0.0",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
 dependencies = [
- "frame-support 33.0.0",
- "frame-support-procedural 28.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3208,9 +3182,9 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3230,19 +3204,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3267,14 +3241,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6e46fd5f6bbbce22fcb19bccce899b4e83e917ba5181b1adae94abb086f124"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3285,15 +3259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d5b1ec42b019aa16d1f9269f74f391c32ce642cb2aad7b1b6a6d65a34e1bc6"
 dependencies = [
  "aquamarine 0.3.3",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
 ]
@@ -3318,54 +3292,12 @@ checksum = "c51ead97e4ac8fdd3b62258bf5f97d2d82412ec0386388ce8296aa23d561536f"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "frame-support"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
-dependencies = [
- "aquamarine 0.5.0",
- "array-bytes 6.2.3",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata",
- "frame-support-procedural 27.0.0",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 30.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.11.0",
- "sp-inherents 30.0.0",
- "sp-io 34.0.0",
- "sp-metadata-ir",
- "sp-runtime 35.0.0",
- "sp-staking 30.0.0",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
- "sp-weights",
- "static_assertions",
- "tt-call",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3380,7 +3312,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural 28.0.0",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3391,43 +3323,23 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
  "sp-weights",
  "static_assertions",
  "tt-call",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a74eda80052082e8acd36c7fa232569ce1f968c7ae2adc56d082039ac9d6ba4"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse 0.2.0",
- "expander 2.1.0",
- "frame-support-procedural-tools 11.0.1",
- "itertools 0.10.5",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -3440,26 +3352,13 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse 0.2.0",
  "expander 2.1.0",
- "frame-support-procedural-tools 12.0.0",
+ "frame-support-procedural-tools",
  "itertools 0.10.5",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.65",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
-dependencies = [
- "frame-support-procedural-tools-derive",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
  "syn 2.0.65",
 ]
 
@@ -3489,43 +3388,22 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 32.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-version 33.0.0",
- "sp-weights",
-]
-
-[[package]]
-name = "frame-system"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 33.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "sp-version 34.0.0",
+ "sp-version",
  "sp-weights",
 ]
 
@@ -3535,13 +3413,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a23446bf524bcc64351ecc5a50925debdc92d50a0b8384c3064dc13b3c64ca3"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3552,7 +3430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54771ae481dd08825d4de28b1b3623163efd9e7c4b59a6db1fb048dcdf73789e"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -3561,10 +3439,10 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f542a58bd43234882faff12062ce94838b3bbca1b6ed6b32180ee153350905f"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -5580,13 +5458,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5598,11 +5476,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6220,17 +6098,17 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00878f866191e08a7f6a74a0378c1d4d759e356d5fc3e3dae51fa414b44fad93"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6240,13 +6118,13 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2908c5abe694fc6d1e9f1dbc9049910cf7086416e0c3214ff4734f02c055d82"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6256,16 +6134,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdecfbbcc55a4050a91bf2180b5b574fe3e20a925c1a836187041974c6f9248"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
- "pallet-transaction-payment 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6275,14 +6153,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14bb2544de653caa76f88156c53ccdea218737ae00ef37b949786bc4c13719f8"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6292,15 +6170,15 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d39e0cf359277a802199f4f78604ddb62f6616e6c625a3b958abec063b1a66f"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6310,14 +6188,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35807c44d2caf67038ae3b3cd948a36014a63e75f96bab3754350deec7cf8e20"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6327,12 +6205,12 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c6fadb06cb9f04998aebabf282e15a6bc35ac36de0c6fccb43a0efb38a755c"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6342,22 +6220,22 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e8bc4e03c6e92cfbac89e9b505ff43fae538915fc277f4597733775c49fa76"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6369,36 +6247,19 @@ checksum = "235a798b0ef83ef012fe79ed01617d84882e682aa40b937ca22e23ee429ab2d7"
 dependencies = [
  "aquamarine 0.5.0",
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56b559fbf1b04e08f42b08c0cb133cf732b4b0cafd315a3a24ba1ae60669d7e"
-dependencies = [
- "docify",
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "frame-system 32.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 35.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -6408,13 +6269,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6424,8 +6285,8 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a846fddc17ec4bb5901f446a1f474090de2778c215aea9ab209631c88cf879"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6433,9 +6294,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6447,8 +6308,8 @@ checksum = "b59f46e15d62db39a20fb254324f5a33cf3c652ca6aa656ba6419ae5c8059336"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6456,12 +6317,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
 ]
 
@@ -6471,16 +6332,16 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56765a826bcdc19693fc327757108d79ac03e7545bc3561a2434bb0238679ee6"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6491,16 +6352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e06a681df643f0bf7225c09b4d33ceaaebfe6ebfb13d0ea686f11d20901e9b"
 dependencies = [
  "bitvec",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6510,17 +6371,17 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "813290bcfde2e10ad4a37763642e22186e28cf7d675cbf525f2276151444008c"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6530,18 +6391,18 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b8c0293db4d8d6632330e8ea1d8ad83711c144fe8b03a14ae15fe1678c7291b"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6551,32 +6412,32 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f5bea608ae6d9e8e12cd1e57d4781ccccf62a87e498bb6318ffe2243815ab4"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae7354ec341dbdd1df77fd0a55708fa49a164901db89920fdca4132f3991ee1"
+checksum = "8117764e8436e9ad3f134c313a65b0dad95f1353349ddd9a78a6b527dbbeb320"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "frame-system 32.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 33.0.0",
+ "pallet-balances",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
@@ -6586,13 +6447,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 30.0.0",
+ "sp-api",
  "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 11.0.0",
- "staging-xcm-builder 11.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
  "wasm-instrument",
  "wasmi",
 ]
@@ -6610,9 +6471,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "9.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7a51646d9ff1d91abd0186d2c074f0dfd3b1a2d55f08a229a2f2e4bc6d1e49"
+checksum = "c611f7343efdff673fec3090ab4ed5c32c63f9756f25f666fb453ef33b26bafb"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6628,14 +6489,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b8fc61dec0ae9760f00fb84a621e383ebb0bd1d2f6a4777bc55977624da5d1"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6645,16 +6506,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb285cd2c58b49219c9980b9c30d4c241920c5a55ae5df44c6e3649dd5057fd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6664,10 +6525,10 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45d7050267a6ce48b2d5530ea5c3b939c8f8a70e42b26db96cb1e859a3dd40c9"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
@@ -6675,9 +6536,9 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "strum 0.26.2",
 ]
@@ -6688,12 +6549,12 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cea3c30507dd5bc3ca2657a2b729dbb9c77f0ae7103778e148d4667d1f0dfe6"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-system 33.0.0",
+ "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6703,17 +6564,17 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4482e691c61ea7d68d09a0d3221a2223b36118874c1923a3733a0ff1a9d4a65"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6724,16 +6585,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3413d41515d5679fa680f96ceac185ede18ac22002837216c9fab863d4a367b7"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6743,21 +6604,21 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63024f2e3aee907a345db4993982b0a853cc330e487d0b7aa2b63bf956bb2a04"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6768,14 +6629,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b59201c3a7fad2acc3623e0e933359588e86ba6445ec4e2ced9a56cbc150658"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6785,18 +6646,18 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859266edee477b8d7c8f07bbe48956f2d0093b7a7466b473df66e6de4dd59445"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6806,15 +6667,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81babd3f9b3af66f27f7af6dfdea1943d16598630c5f4eda34ec56bdb7185dbd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6824,15 +6685,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d72c43d36e246e388b911ce85176962eeaf7893acb472fe1c4377c7007f886d"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6843,16 +6704,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cf3baf644a42f0520f030e91e24c72e3d6691f7abc347345219b2e744fc835"
 dependencies = [
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -6863,16 +6724,16 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f6cdaa2b8423f910e260b93065b8c63c7ebbc21c288419bc7a9aa0ed7a14fa"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6882,14 +6743,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4957a1571ca0a761520942623d7d1ff71f2831edfc2f2fc43ad454682e50ad95"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6899,14 +6760,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9317c665f1692637b3ede02fef4153ae3c4a4fb4b196bbea07a6a011546ab74"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6916,16 +6777,16 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1edc38d7ba687163bdf2562b1fd8d440d63648c193b6c9e899ea12a607747ed"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
  "sp-tracing",
 ]
@@ -6936,18 +6797,18 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd63c332aa3c111d10268c29aa439180d4b94c8adecbf526f0a04aeea46bea1"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6959,7 +6820,7 @@ checksum = "e3980bcda50ec619f93dbb8b73f824413ee5dccabe3511fca4454c49857c1483"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -6969,15 +6830,15 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d02ba6a9a9c27685404f979534ab254f0cda028857ebdb19f7cb9aa0f52bc6b"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6987,13 +6848,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de8b5190c4421f6550504bd1753f82492c28cda5b1ccb6c2759494cdfa431207"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-babe",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -7001,8 +6862,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7013,15 +6874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8bc500ff1d3292950a7d1b50b0e26f7cd9f886cd4a577883267d36a1da1361"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7031,15 +6892,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20718f6531ad2adf84ed0b1f845f29e29987b7fd1ccb738134c60e77177f1d0"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7049,13 +6910,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a73160cf5aa5ebf1f07eb1134328b272ab16070028c8c1ee9f800ffa3a5c03db"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7065,17 +6926,17 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "082ef6517f3901106bc642a7bb35b9c8345cbe55c5c60dbf6b09081b2e3c5695"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7085,13 +6946,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06afe44a0484ad3c8b943c555fe4d7ccc9da3b3cd1093ddb6a8984bae6f130f4"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7102,16 +6963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b6c4f5bc65be570a065907239d3215036d3e29edbd0ea5c6cd01246e2ba3959"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7121,13 +6982,13 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4b63ec79ab485d54cf79fd5ef574bb7f8f4e094e4a7d11b012a820d4324b62"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7138,14 +6999,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7570e307118a4663dd3a1d1c949f84a169ef932666e69f7fcf4357781c8c1a4e"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -7156,21 +7017,21 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925f793adb1d53c05233ffd2644ca37890d56c9716475108b975969a445d10b3"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
- "sp-state-machine 0.40.0",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -7179,14 +7040,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca61297e13c15fef1e4d3b7f2884e70c772be3a9448977ba23954e2c4bcea4bd"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
 ]
@@ -7197,16 +7058,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8584534df25227dd43d80803ea1978af55bf70aad5aa57c83dc3de883b1f1c73"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7216,10 +7077,10 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f68e48f3d79e0cbb9462eacc0c85c80003924124a893465047f159278338036d"
 dependencies = [
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7227,10 +7088,10 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto 35.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7263,8 +7124,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c431ab74db8258b39fe829fb7345d38064ef7fb1ce2014b074f586303d7dee67"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-staking 31.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7273,15 +7134,15 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db0ce6ccf9e1d2fe2d0b26cecce995e4b095b31bbf9f0492024fbfd4924961a"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7292,13 +7153,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ee43e8bb38a50a234ef49198413483562e229ca20d8e9d9f78b756244f6d7c"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7309,15 +7170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5982a7cc371e2b9be504465bb6e47bc27dba0b98ee9794d7fc797c24244fb6d9"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -7329,34 +7190,17 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e0d02dcd034cb57cb25f1301c6e6c43b8191b96b049e7d013564aaf5d3c6af"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedf412abd258989da4a26946f7e480c4335ffc837baef4ef21ba91cd56ba8ee"
-dependencies = [
- "frame-support 32.0.0",
- "frame-system 32.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7366,14 +7210,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7386,11 +7230,11 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7400,10 +7244,10 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f274055d2c61888689889d6e9b9266b163e1ed298967b55bf961db26b11a60fe"
 dependencies = [
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7414,16 +7258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a11166748c80a432c52d5cc99c2b0e1d2b88592e0ad71eec7cb9f360e375c7"
 dependencies = [
  "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7433,14 +7277,14 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1c70a4abf287304214b16d9eb88f13c991bd696f9e5318fc68e74df9802037"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7450,13 +7294,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a5b229675f299af7aa40749c579570dce4ab19739779a45f5a87da118af8ef"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7466,13 +7310,13 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "249172db9f2b014a6e9d4b5c6d663bcbcb0055c1c2c7564e7bd0488ecb1f15b8"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7483,21 +7327,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9e654cf90682370fe20a04904cb02df993c3b0dcfad861abcf2811f4fa6085"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "xcm-fee-payment-runtime-api",
 ]
 
@@ -7507,18 +7351,18 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b7038af027fcce5ba3d2f99b941fb997a5556f1fa0b8a7e7e23a448be1bb85"
 dependencies = [
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -7536,7 +7380,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7564,16 +7408,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-timestamp",
- "staging-xcm 12.0.0",
+ "staging-xcm",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -7593,11 +7437,11 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7605,38 +7449,38 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -7648,13 +7492,13 @@ checksum = "43acd23527a3471b1c596b809591edf78d6113bba172fff4a96412d560dfea59"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7663,12 +7507,12 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-parachain-info",
- "staging-xcm 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -8086,10 +7930,10 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
 ]
@@ -8111,23 +7955,10 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "tokio-util",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9792d6e3323b0bd7372a489bd3dd52afb09436919d073d45302f8e55f48ea4fd"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime 35.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -8139,7 +7970,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -8163,7 +7994,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8180,7 +8011,7 @@ dependencies = [
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie 34.0.0",
+ "sp-trie",
  "thiserror",
 ]
 
@@ -8200,7 +8031,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -8276,10 +8107,10 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "tracing-gum",
 ]
@@ -8360,7 +8191,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -8432,7 +8263,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "thiserror",
  "tracing-gum",
 ]
@@ -8488,12 +8319,12 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 12.0.0",
+ "polkadot-core-primitives",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "rand 0.8.5",
  "slotmap",
@@ -8533,7 +8364,7 @@ dependencies = [
  "libc",
  "nix 0.27.1",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
@@ -8542,7 +8373,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8625,7 +8456,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8641,16 +8472,16 @@ dependencies = [
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
  "zstd 0.12.4",
 ]
@@ -8687,11 +8518,11 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8725,7 +8556,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8749,28 +8580,10 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe77e2febc4b87e7c0a63f857ce5c32a2680cae5f9c2740285cd7378ed1586ca"
-dependencies = [
- "bounded-collections",
- "derive_more",
- "parity-scale-codec",
- "polkadot-core-primitives 11.0.0",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-weights",
 ]
 
 [[package]]
@@ -8782,11 +8595,11 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -8801,21 +8614,21 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -8842,13 +8655,13 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -8860,17 +8673,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3effc5cafb231ede1c394abce9575c292e95170e11ee1ecc5644d25cf35b54b9"
 dependencies = [
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -8879,7 +8692,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -8890,18 +8703,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -8912,7 +8725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cfaa021e4639e9fcba7c40111d93720b82cea98d667889760e46a40137e3d47"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -8928,15 +8741,15 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -8944,8 +8757,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand 0.8.5",
@@ -8953,19 +8766,19 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -8977,10 +8790,10 @@ checksum = "fc6acbf05debbbab4831318fdbe0619742573dda47721af7e2ff042def2ec77a"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -8991,7 +8804,7 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -9001,7 +8814,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 12.0.0",
+ "polkadot-core-primitives",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -9026,7 +8839,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
@@ -9059,7 +8872,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9068,21 +8881,21 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version 34.0.0",
+ "sp-version",
  "sp-weights",
- "staging-xcm 12.0.0",
+ "staging-xcm",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
@@ -9109,7 +8922,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking 31.0.0",
+ "sp-staking",
  "thiserror",
  "tracing-gum",
 ]
@@ -10027,10 +9840,10 @@ checksum = "224e7b002c0ba04bcee4bf25e2d90ff1895a9c1171fd8c3162c63a558c33a0d4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10040,7 +9853,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -10073,7 +9886,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -10082,7 +9895,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -10092,7 +9905,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -10100,21 +9913,21 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 34.0.0",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-fee-payment-runtime-api",
@@ -10126,15 +9939,15 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578bde81aeca421df7d898726f0d3d9caea11eed87d77760be71177ce071977f"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -10451,12 +10264,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10475,12 +10288,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10491,13 +10304,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4190e69ccdf1b10c530e110345d67c6347aa0bc03fa56723103d834fb8ac907d"
 dependencies = [
  "parity-scale-codec",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-trie 34.0.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10521,10 +10334,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.12.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-tracing",
 ]
 
@@ -10576,8 +10389,8 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
 ]
@@ -10596,17 +10409,17 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
  "sp-storage",
- "sp-trie 34.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10632,9 +10445,9 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
- "sp-trie 34.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10653,12 +10466,12 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10678,17 +10491,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10714,8 +10527,8 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10723,9 +10536,9 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents 31.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10742,14 +10555,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10774,8 +10587,8 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "sc-utils",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10784,7 +10597,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10807,7 +10620,7 @@ dependencies = [
  "serde",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10822,7 +10635,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10856,8 +10669,8 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10865,7 +10678,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10887,7 +10700,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10910,9 +10723,9 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -10927,14 +10740,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -10999,7 +10812,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11011,7 +10824,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.2",
  "serde_json",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -11038,12 +10851,12 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11088,7 +10901,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11115,7 +10928,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11134,7 +10947,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11157,7 +10970,7 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11192,7 +11005,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11216,7 +11029,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11261,12 +11074,12 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -11301,16 +11114,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
- "sp-version 34.0.0",
+ "sp-version",
  "tokio",
 ]
 
@@ -11330,8 +11143,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
 ]
 
@@ -11376,12 +11189,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
- "sp-version 34.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11429,20 +11242,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11494,7 +11307,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11516,7 +11329,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -11560,11 +11373,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11601,11 +11414,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11625,7 +11438,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12126,7 +11939,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -12314,29 +12127,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8abd1d0732054ad896db8f092abe822106f1acf8bbc462c70f57d0f24c0dcdf"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 18.0.0",
- "sp-core",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime 35.0.0",
- "sp-runtime-interface",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-trie 33.0.0",
- "sp-version 33.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "sp-api"
 version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b500647cfe266d58781f44af9b13c3bd57fb3be08642f2a9f13e024cc5e22359"
@@ -12345,32 +12135,17 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 19.0.0",
+ "sp-api-proc-macro",
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
+ "sp-trie",
+ "sp-version",
  "thiserror",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681e80c1b259ee71880cd3b4ad2a2d41454596252bd267c3edf4e14552ab40e1"
-dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander 2.1.0",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -12390,20 +12165,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505fad69251900048ddddc6387265e1545d1a366e3b4dcd57b76a03f0a65ae7"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 34.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57541120624a76379cc993cbb85064a5148957a92da032567e54bce7977f51fc"
@@ -12412,7 +12173,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -12440,9 +12201,9 @@ checksum = "6d8494eafd70194198b7fd82446da59380c7346bedf68e83dfbdb5f338395437"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12451,9 +12212,9 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51cf3d8fb96de98aecdd32cdd4a735af4d84fae274314f411f95c89d4dff6ad3"
 dependencies = [
- "sp-api 31.0.0",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12467,11 +12228,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "schnellru",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-database",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12485,9 +12246,9 @@ dependencies = [
  "futures",
  "log",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12500,11 +12261,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12518,12 +12279,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12537,14 +12298,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12559,11 +12320,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12684,17 +12445,6 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
-dependencies = [
- "serde_json",
- "sp-api 30.0.0",
- "sp-runtime 35.0.0",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7605a8ed2c06d348c26055b7907c3d2d62f984666e9025b57df4895f865f5901"
@@ -12702,22 +12452,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcba3b816fdfadf30d8c7c484e1873f1af89ed2560c77d2b2137d152cc5a585"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 35.0.0",
- "thiserror",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12730,35 +12466,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44ed47247b6eee76ff703f9fa9f04f99c4104ac1faf629e6d1128e09066b57b"
-dependencies = [
- "bytes",
- "ed25519-dalek 2.1.1",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive",
- "rustversion",
- "secp256k1",
- "sp-core",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine 0.39.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 33.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -12780,10 +12489,10 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine 0.40.0",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie 34.0.0",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -12795,7 +12504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d2c495248bd141fe04ec639785c874949b2c552c00ea4afc4c183c654466ce"
 dependencies = [
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12840,8 +12549,8 @@ checksum = "2242e7a802822109e007c3d6ee79640f8dc3abee7139d34ce029c7478361be8c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -12855,10 +12564,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12873,7 +12582,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12882,9 +12591,9 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cbbd2096fda34c2f6f9f268c808ca280c08565e759309ea24f17dcd0808097b"
 dependencies = [
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12911,31 +12620,6 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ce931b7fbfdeeca1340801dbd4a1cae54ad4c97a1e3dcfcc79709bc800dd46"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 34.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-io 34.0.0",
- "sp-std",
- "sp-weights",
-]
-
-[[package]]
-name = "sp-runtime"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
@@ -12951,10 +12635,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 35.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-std",
  "sp-weights",
 ]
@@ -13001,25 +12685,11 @@ checksum = "9c558f85486882433adcfdfe05c5e82972a7be1a6d7fa68a6213b70ec1d86068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-core",
  "sp-keystore",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43ec7f6c9759ba3011a16bb022afe056bc26f88b3c424598737cba71d3ef0"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime 35.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13033,28 +12703,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d9078306c3066f1824e41153e1ceec34231d39d9a7e7956b101eadf7b9fd3a"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.2",
- "rand 0.8.5",
- "smallvec",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie 33.0.0",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13072,10 +12721,10 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie 34.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -13092,12 +12741,12 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -13130,8 +12779,8 @@ checksum = "bdb7768c895643e315f9bcfacdd61e283b78c862d976fd081a508cf7239c8643"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13153,8 +12802,8 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207cb372504cf86237fa63953a0aa40d7596d1c9cf21175a56346ed1744eb8fe"
 dependencies = [
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13167,33 +12816,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 31.0.0",
- "sp-runtime 36.0.0",
- "sp-trie 34.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f5b3620a1c87c265a83d85d7519c6b60c47acf7f77593966afe313d086f00e"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.2",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core",
- "sp-externalities",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
- "trie-root",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -13216,26 +12841,8 @@ dependencies = [
  "sp-externalities",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
  "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba2f18b89ac5f356fb247f70163098bc976117221c373d5590079a5797a3b43"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror",
 ]
 
 [[package]]
@@ -13250,7 +12857,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13355,31 +12962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4efd2f6285b97c1797f8451afb9834a90bd7b90712e6d1a3df8f68f9e7357ea6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "staging-xcm"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aded0292274ad473250c22ed3deaf2d9ed47d15786d700e9e83ab7c1cad2ad44"
-dependencies = [
- "array-bytes 6.2.3",
- "bounded-collections",
- "derivative",
- "environmental",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-weights",
- "xcm-procedural 8.0.0",
 ]
 
 [[package]]
@@ -13398,30 +12986,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-weights",
- "xcm-procedural 9.0.0",
-]
-
-[[package]]
-name = "staging-xcm-builder"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0681b0a478c2f5e1f1ae9b7e8e4970d79ec8ef94f4efebc011ea335822bc264e"
-dependencies = [
- "frame-support 32.0.0",
- "frame-system 32.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-transaction-payment 32.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 10.0.0",
- "scale-info",
- "sp-arithmetic",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-weights",
- "staging-xcm 11.0.0",
- "staging-xcm-executor 11.0.0",
+ "xcm-procedural",
 ]
 
 [[package]]
@@ -13430,43 +12995,21 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
 dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 12.0.0",
- "staging-xcm-executor 12.0.0",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb518e82e9982c90c32b66263642385fc186c76f329766884d3360b65e84dd46"
-dependencies = [
- "environmental",
- "frame-benchmarking 32.0.0",
- "frame-support 32.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io 34.0.0",
- "sp-runtime 35.0.0",
- "sp-std",
- "sp-weights",
- "staging-xcm 11.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -13476,19 +13019,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
 dependencies = [
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 12.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -13637,11 +13180,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 31.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13669,10 +13212,10 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime 36.0.0",
- "sp-state-machine 0.40.0",
- "sp-trie 34.0.0",
- "trie-db 0.29.1",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+ "trie-db",
 ]
 
 [[package]]
@@ -13693,10 +13236,10 @@ dependencies = [
  "polkavm-linker",
  "sc-executor",
  "sp-core",
- "sp-io 35.0.0",
+ "sp-io",
  "sp-maybe-compressed-blob",
  "sp-tracing",
- "sp-version 34.0.0",
+ "sp-version",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.13",
@@ -14321,19 +13864,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
-dependencies = [
- "hash-db",
- "hashbrown 0.13.2",
- "log",
- "rustc-hex",
- "smallvec",
 ]
 
 [[package]]
@@ -15114,11 +14644,11 @@ checksum = "13acc56783ce7fca15017890034ed043cb91de2caab28a91a5b4209a1214eed4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 33.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -15129,7 +14659,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -15166,7 +14696,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 33.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -15175,7 +14705,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -15184,30 +14714,30 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 31.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 34.0.0",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
- "staging-xcm-executor 12.0.0",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-fee-payment-runtime-api",
@@ -15219,15 +14749,15 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb9a91bc8d5ec0a260735651284eb4420c1a2de62b2430cf16c723186eabd28"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 36.0.0",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -15638,26 +15168,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92be74937c8012c951c667bb0fb016634ab4adeac46f8106aef331f836059167"
 dependencies = [
- "frame-support 33.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 12.0.0",
-]
-
-[[package]]
-name = "xcm-procedural"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4717a97970a9cda70d7db53cf50d2615c2f6f6b7c857445325b4a39ea7aa2cd"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.65",
+ "staging-xcm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -917,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e9ce60db859f26172c1428b251e628751850e7862065104e750310c6afbad"
+checksum = "0181e1058f555b2e0f177e82042a6edd9c342ed4ec826376b2e5aa1cd29fc853"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -1143,6 +1143,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
+ "serde",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1283,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -1512,6 +1535,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169c6bebaa58a8f0f2078747919ebd98df45d0d018a0f8caa66ec15e2ad43d4"
+checksum = "56af3de66b0512db180c091ccbf673ed198f75a25b602289ee247251bf966c39"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1626,15 +1664,15 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ffccac45cddcbb37b8c18283bd57638f648f725091d28c3ac3be515f8dd1d"
+checksum = "aeaa7ba76cb14097c15105674be6ec74e58bc1313cb322a97e038c9abfbf09c4"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1647,18 +1685,18 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d112f874c998d174f034532d238d5e0616c3455f8bf9bb5946c5617e7c7c0f"
+checksum = "a999414a27e99ed73f447aba5f9382bb81fbf3e98a8c1a8874f71f929d094759"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1681,17 +1719,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1699,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6fc5e8237ff0e649c24fb1c31407fddb05cdf4773f83ca2a7b497305ae19b0"
+checksum = "fc06ef9519e39f72915033e0aec418383707290103c8d9ba8ffbc70ddfd515e7"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1720,34 +1758,34 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
- "sp-trie",
+ "sp-trie 34.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb01ccc8275a4ded0caf788e561c7400e630585d34feec8a22700cbbe44f8bb"
+checksum = "e8a533049ee548528aada1c09c5827c3a2fd8cce96ecb4ff1fca241abfef87ba"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f70b5f3eb4385498880a74684be6bd17669f2a2b5c7db805eef16337af1d0cd"
+checksum = "b1da1f0f7be1258a0f1a4a43ca0dd4a1add8e2e639dceaf310fc136d6835fe00"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1756,22 +1794,22 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0342e88f2079d7b3287bd52b4e0f7885e563439ff2e8b8d36f99aa596b219e"
+checksum = "cb5426870af0eac3277135aac62dafea82f9c42b501193bca5483c2eb9358b5b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1781,22 +1819,22 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e877fcdae06369ce17fd4d1fd0467d21b08338f7c944e225c5461472f54a166a"
+checksum = "286e7071e367a4ee6f1e9c674a27118c6f04ef273b94194082b8155255451503"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1808,20 +1846,20 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920c64fd704a14c571b79f5d0f19dd2638240f6a9f633f02072a35ab30db3341"
+checksum = "a909ed00f0280a9f53838616bb8f56b180116838a8242b847a18c8950e7cc4ec"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1846,39 +1884,39 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b720fe4cd7d2e6282c0c13fbbcf68cd7dcb19d060b5032709c34582d574ad"
+checksum = "fa2703d49952e0538c4d05fe1f1114e62741871693e862fc68ab56ae6b3b5230"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b426ade835b03cb4eb0b7299a5918e96cb53ed0e38b0d07676be7ed8df772ff"
+checksum = "249e7657ac378241ae6c437df851bbe0971d93df756d1201315395b5ce856974"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1886,28 +1924,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
- "sp-version",
- "staging-xcm",
- "trie-db",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
+ "staging-xcm 12.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -1924,48 +1962,48 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b08b5e3bba454f8eaa01a7507c1bacde9343a7a67fc20801e59e0c9c0ec9db"
+checksum = "2be9d77e00ad1dbcf12dcd81c2758d651adf6e3072f3cb51c11d8739426f4cbb"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f14dc8bc002babf1596515a2f1c0158ddeccbf1ef7f5656fe71c8e1fa4bde55"
+checksum = "6b7737eb5d81bcd79df114e711927ba19c2dbd312f245ae03b76d330abb3506d"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
+ "staging-xcm 12.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5810a98c95f4219d7dcd6bd89d0c149fc45162e7e0c335579ba5545ec4b9c216"
+checksum = "fb2939bc9749f4a5299ae20f7756ce69ce3e63f72ed936d7f1db0189187f70a1"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -1973,117 +2011,119 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-executor 12.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e91498fef0a7502070d55949b3413361060b1e0556592ed851f220f8aafb4"
+checksum = "a61fa5dad966e340092a4521b56b43dddce5bf466ddb07d9a01c534e63e4e0b7"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 12.0.0",
  "polkadot-primitives",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a1b925068ede5dd9f571f3afcfca877b2f94f988d308d757224464a27bc6ce"
+checksum = "ad51d36ea156ef84d7e8ca5cea881867d3540e8dfdb8ea6b9d2b9190197a22a5"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 12.0.0",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "sp-trie",
- "staging-xcm",
+ "sp-trie 34.0.0",
+ "staging-xcm 12.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01642f846368bd7305a2b9c9874a4280b5097c62c33da84b2048e2e3b38bb03"
+checksum = "9e6d358b1c4062048e47635b49d066131e4eef6314c0e81501d4c9c2e028dbc4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9ce5326ecf86a75ee9a2d53ba8a6950f98d278a1cc88480f1dcbc90077d7dc"
+checksum = "e736734a6b4b0308d931756c30c3472fa5ec99a95be14f70567f25c97b3822cc"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8596e26f2d3b2c70c00b695eb9edc8fca4533105bf6b2f0c4c0ecc8075bf99"
+checksum = "e68201ff0845be29c3c0e7e408e5f9d4de0e01b55787fe2c8709e658cbd2c937"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b02524805657a76fcca354c2a9466580d7f980a9a9616a4ac1cb91597d1f451"
+checksum = "5ee70eb2f55d20a965e3538fc96aac2801815af510b4460e8a5783f5197e0872"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
+ "frame-support 33.0.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842505bb9820f5d3c7d2561ed9783cd495d3665729e42590b12641e73c69fcf5"
+checksum = "d9557dc83e9fa1ab863f6070f9d325a8075cb00478f2a756132ed87b4e3a29ed"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2097,18 +2137,18 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a457e637e70eccddfdd06feaf5736e3fa3fd9955ef2dc9ef696cdea640fc6e4c"
+checksum = "9ed3c0bd4319881da5f94b77380db377499e129a176184430b308d9d7bd1d9a8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2117,17 +2157,17 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f946e5e8f6199bad20b4e65b3e56fb6feeb3c59d50ede9909dcfa9c73697db2"
+checksum = "d3ffcf7b86d4a140ba5ba6c94537ae54334c594bb4cf7a6464c848859b7970d1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -2138,7 +2178,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 12.0.0",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2156,11 +2196,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2168,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b173a09d24c4ea2b6f90eb682276f844db7b180651f22a9e918f8bac0642075f"
+checksum = "800d957241a91a58b55a3ee9f607caea2660a01d2fcfc285bdcec262a3d8882d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2182,7 +2222,7 @@ dependencies = [
  "parity-scale-codec",
  "pin-project",
  "polkadot-overseer",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -2191,14 +2231,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-storage",
- "sp-version",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2208,17 +2248,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f27d17ab307b0e255431fa21113f2aca1e0b27f54d272198972b29e2eeb88b"
+checksum = "e8f509dfa3d3380fd0023f4cbd15bfeccd333de8d0140f85d13e6b295fb53dd7"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
@@ -2609,8 +2649,17 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature",
+ "signature 2.2.0",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2620,7 +2669,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -2630,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek 4.1.2",
- "ed25519",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
@@ -2659,7 +2722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek 4.1.2",
- "ed25519",
+ "ed25519 2.2.3",
  "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
@@ -2709,6 +2772,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2994,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3032,6 +3107,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fork-tree"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,20 +3151,46 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
+ "frame-support 32.0.0",
+ "frame-support-procedural 27.0.0",
+ "frame-system 32.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
+dependencies = [
+ "frame-support 33.0.0",
+ "frame-support-procedural 28.0.0",
+ "frame-system 33.0.0",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3083,18 +3199,18 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be33471ac5fa10ca585d3e06642cc8c754ecd9cb8a76905bf648cff17990e32"
+checksum = "e13ce497c53ed3a9aadadfc3ea7904b00717965156c0e2e6dd16fc049a379cd7"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3102,9 +3218,10 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
+ "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
@@ -3113,18 +3230,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3144,38 +3262,38 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c897b912f222280123eedee768b172ed74600292dfbb22843c95c9177e97358"
+checksum = "ee6e46fd5f6bbbce22fcb19bccce899b4e83e917ba5181b1adae94abb086f124"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbd97de3a8af65a9e1752b465fc19c7fe19c62ca1842ccec47f3002667c2172"
+checksum = "01d5b1ec42b019aa16d1f9269f74f391c32ce642cb2aad7b1b6a6d65a34e1bc6"
 dependencies = [
  "aquamarine 0.3.3",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -3193,26 +3311,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-remote-externalities"
-version = "0.39.0"
+name = "frame-metadata-hash-extension"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4afeb0769c0ef010c0dcc681a60167692a1cd52f0c0729b327a4415facddc5"
+checksum = "c51ead97e4ac8fdd3b62258bf5f97d2d82412ec0386388ce8296aa23d561536f"
 dependencies = [
- "futures",
- "indicatif",
- "jsonrpsee",
+ "array-bytes 6.2.3",
+ "docify",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "spinners",
- "substrate-rpc-client",
- "tokio",
- "tokio-retry",
+ "scale-info",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -3227,7 +3338,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 27.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3238,18 +3349,60 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d04fc1fdbc7bdcb1cb54834e16a5194e5a16a25bfdaca1b761ee9ff4963366f"
+dependencies = [
+ "aquamarine 0.5.0",
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 28.0.0",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 31.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -3267,7 +3420,27 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse 0.2.0",
  "expander 2.1.0",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 11.0.1",
+ "itertools 0.10.5",
+ "macro_magic",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8eaf3bb331b98427158733e221bd6fb79e9f213da55b305e159dc023d41fd2"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse 0.2.0",
+ "expander 2.1.0",
+ "frame-support-procedural-tools 12.0.0",
  "itertools 0.10.5",
  "macro_magic",
  "proc-macro-warning",
@@ -3282,6 +3455,19 @@ name = "frame-support-procedural-tools"
 version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
+dependencies = [
+ "frame-support-procedural-tools-derive",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b5cc8526c9aad01cdf46dcee6cbefd6f6c78e022607ff4cf76094919b6462"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3309,55 +3495,76 @@ checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "sp-version",
+ "sp-version 33.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "frame-system"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 33.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-version 34.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4976a4dfad8b4abff9dfc5e1a5bcdfa0452765f5c726805499ea30be0df4eaa4"
+checksum = "1a23446bf524bcc64351ecc5a50925debdc92d50a0b8384c3064dc13b3c64ca3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24451c0fef0c35c50bf577aadd16bb3c7b9eb74f12bb1708114d24c6f750e165"
+checksum = "54771ae481dd08825d4de28b1b3623163efd9e7c4b59a6db1fb048dcdf73789e"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
 ]
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883f2a531ab7857e8b4bb09997f1333635da1b5e627ac1651c16b5e5152d8fa3"
+checksum = "8f542a58bd43234882faff12062ce94838b3bbca1b6ed6b32180ee153350905f"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -3598,7 +3805,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
 ]
 
@@ -3654,7 +3861,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -3973,6 +4180,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -4084,19 +4301,6 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
-
-[[package]]
-name = "indicatif"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
-]
 
 [[package]]
 name = "inout"
@@ -4250,7 +4454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
  "jsonrpsee-core",
- "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
@@ -4295,7 +4498,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4303,26 +4506,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tower",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -4572,7 +4755,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
  "thiserror",
@@ -4591,7 +4774,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.2",
  "smallvec",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.22.0",
 ]
 
 [[package]]
@@ -4623,12 +4806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
  "bs58 0.4.0",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "log",
  "multiaddr",
  "multihash 0.17.0",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
  "zeroize",
@@ -4653,7 +4836,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
  "thiserror",
@@ -4675,11 +4858,11 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
  "tokio",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
  "void",
 ]
 
@@ -4711,7 +4894,7 @@ dependencies = [
  "log",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -4733,7 +4916,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "void",
 ]
 
@@ -4753,7 +4936,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.2",
  "quinn-proto",
- "rand",
+ "rand 0.8.5",
  "rustls 0.20.9",
  "thiserror",
  "tokio",
@@ -4771,7 +4954,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand",
+ "rand 0.8.5",
  "smallvec",
 ]
 
@@ -4790,7 +4973,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "void",
@@ -4838,7 +5021,7 @@ dependencies = [
  "rustls 0.20.9",
  "thiserror",
  "webpki",
- "x509-parser",
+ "x509-parser 0.14.0",
  "yasna",
 ]
 
@@ -4926,7 +5109,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -5033,6 +5216,61 @@ dependencies = [
  "blake2 0.8.1",
  "chacha",
  "keystream",
+]
+
+[[package]]
+name = "litep2p"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b53e78902be9d0d77df70677242b7fc9815a33a168949b5480ee089e16535e7"
+dependencies = [
+ "async-trait",
+ "bs58 0.4.0",
+ "bytes",
+ "cid 0.10.1",
+ "ed25519-dalek 1.0.1",
+ "futures",
+ "futures-timer",
+ "hex-literal",
+ "indexmap 2.2.6",
+ "libc",
+ "mockall",
+ "multiaddr",
+ "multihash 0.17.0",
+ "network-interface",
+ "nohash-hasher",
+ "parking_lot 0.12.2",
+ "pin-project",
+ "prost 0.11.9",
+ "prost-build",
+ "quinn",
+ "rand 0.8.5",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "serde",
+ "sha2 0.10.8",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.7",
+ "static_assertions",
+ "str0m",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "trust-dns-resolver 0.23.2",
+ "uint",
+ "unsigned-varint",
+ "url",
+ "webpki",
+ "x25519-dalek 2.0.1",
+ "x509-parser 0.15.1",
+ "yasna",
+ "zeroize",
 ]
 
 [[package]]
@@ -5153,12 +5391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5169,6 +5401,15 @@ name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
@@ -5241,6 +5482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.3",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,7 +5514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
  "futures",
- "rand",
+ "rand 0.8.5",
  "thrift",
 ]
 
@@ -5306,7 +5561,7 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.5.0",
@@ -5316,38 +5571,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463f3038aebf0766b75c231e293293dec7b85f2358120a2696470159008ddfd2"
+checksum = "686cce3698548808445b0bbc8348a30cafc7d6fc6dbf8df0ef5027b08e4fe037"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17ec87c5d04009e7d7b149abb2aa8495e2893c5920ce4a83679c76e5d6320f7"
+checksum = "70db3d6f4fdfd688a4f995f5eb3ee9764b766a01f4a4789fa5469a02d213ee12"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -5430,10 +5685,14 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "core2",
  "digest 0.10.7",
  "multihash-derive 0.8.0",
  "sha2 0.10.8",
+ "sha3",
  "unsigned-varint",
 ]
 
@@ -5559,7 +5818,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5635,6 +5894,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,6 +5972,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -5778,12 +6059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5832,10 +6107,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.3.0+3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5886,170 +6209,177 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-asset-conversion"
-version = "14.0.0"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66fbfb4b9a3a6430f5925a09257c61a048bf0dfbad26f814e0f0e517f43c06a"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pallet-asset-conversion"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00878f866191e08a7f6a74a0378c1d4d759e356d5fc3e3dae51fa414b44fad93"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63f90c10e0746fce0512e37e1a354fe8c48f32e4e20211e0c1ac9b0e4b3febb"
+checksum = "a2908c5abe694fc6d1e9f1dbc9049910cf7086416e0c3214ff4734f02c055d82"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27f76cc9151160c08fcee2e095b91048a2d1cb041b7c022a88f98ba220827b4"
+checksum = "cbdecfbbcc55a4050a91bf2180b5b574fe3e20a925c1a836187041974c6f9248"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "pallet-transaction-payment 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0d9362dc1b75cead58f5e9a6004d305f81b2bf38c52e5454d1d868e2cc98f"
+checksum = "14bb2544de653caa76f88156c53ccdea218737ae00ef37b949786bc4c13719f8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb27318bf97e8116b1383c726427ab8d6d9dac4da99c8540a247518398c2a55"
+checksum = "7d39e0cf359277a802199f4f78604ddb62f6616e6c625a3b958abec063b1a66f"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303077e7ec8808fdd9df22a6eaf9d38932a9b7df07c29423935384cf43babb2f"
+checksum = "35807c44d2caf67038ae3b3cd948a36014a63e75f96bab3754350deec7cf8e20"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-authority-discovery",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3544ca79d7b1f3b9a0efe6b54038143962e8b05d57a3a4172cd11e7216c43d6"
+checksum = "a9c6fadb06cb9f04998aebabf282e15a6bc35ac36de0c6fccb43a0efb38a755c"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac02d082761843190fddfea58ce3a8cf042e92d2d78bb21426d2f960880a875c"
+checksum = "d1e8bc4e03c6e92cfbac89e9b505ff43fae538915fc277f4597733775c49fa76"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-babe",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664e6da2fe296a6597f2508f8754bfedaf06b5fc7bc657f7327b7d91896f84f7"
+checksum = "235a798b0ef83ef012fe79ed01617d84882e682aa40b937ca22e23ee429ab2d7"
 dependencies = [
  "aquamarine 0.5.0",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -6061,24 +6391,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b56b559fbf1b04e08f42b08c0cb133cf732b4b0cafd315a3a24ba1ae60669d7e"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-balances"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
+dependencies = [
+ "docify",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36b750d43f02589284a26ae4bcdaa9cd957abd12ffcedccf5de7f3ede20e14e"
+checksum = "42a846fddc17ec4bb5901f446a1f474090de2778c215aea9ab209631c88cf879"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6086,22 +6433,22 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0ec062385375cee83f44985bf4d32c86e6ca4018e0a867b448a9a572896388"
+checksum = "b59f46e15d62db39a20fb254324f5a33cf3c652ca6aa656ba6419ae5c8059336"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6109,108 +6456,110 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe92916d8bb2f2ce84195ae5e6baec83c5a65bf685613d7cc207f0b8fd26ea43"
+checksum = "56765a826bcdc19693fc327757108d79ac03e7545bc3561a2434bb0238679ee6"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d73ed3f977ca5874e32936f7605e83e96f7eb0cb7fca46b9a3f5a8df1933d5"
+checksum = "58e06a681df643f0bf7225c09b4d33ceaaebfe6ebfb13d0ea686f11d20901e9b"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "log",
  "parity-scale-codec",
  "scale-info",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5612487abb09a9e5b6f3a694639fd0826a8b3bae1335047899f032f292f7f410"
+checksum = "813290bcfde2e10ad4a37763642e22186e28cf7d675cbf525f2276151444008c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "13.0.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0724831b2b1775542055c80918e78478953ee8d6777962a947404f22001c75"
+checksum = "7b8c0293db4d8d6632330e8ea1d8ad83711c144fe8b03a14ae15fe1678c7291b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-session",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f84d7ad169667bcf184da694db6322bd9a68d9d0bb05b2727005cfadd2b8a17"
+checksum = "c2f5bea608ae6d9e8e12cd1e57d4781ccccf62a87e498bb6318ffe2243815ab4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -6222,28 +6571,28 @@ checksum = "3ae7354ec341dbdd1df77fd0a55708fa49a164901db89920fdca4132f3991ee1"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances",
+ "pallet-balances 33.0.0",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "scale-info",
  "serde",
  "smallvec",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 11.0.0",
+ "staging-xcm-builder 11.0.0",
  "wasm-instrument",
  "wasmi",
 ]
@@ -6274,377 +6623,377 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43080685819927c77fb38dda17e593eab2478406d674dd8c69200129cf613e77"
+checksum = "f0b8fc61dec0ae9760f00fb84a621e383ebb0bd1d2f6a4777bc55977624da5d1"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83740afbabdabd41a9af23e1085db431b7d0aa10e542f6e1862aa14ff76eeec9"
+checksum = "fcb285cd2c58b49219c9980b9c30d4c241920c5a55ae5df44c6e3649dd5057fd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4127300982c54fb31630a3a002daeb060556c0d0ca17031975fe25d613f432"
+checksum = "45d7050267a6ce48b2d5530ea5c3b939c8f8a70e42b26db96cb1e859a3dd40c9"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d47f77fc73b1caf6317515e884a1451786c8b71fddd910b753a73da7ee4fe84"
+checksum = "3cea3c30507dd5bc3ca2657a2b729dbb9c77f0ae7103778e148d4667d1f0dfe6"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-system",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fe6701c248d87e489e998230180b112e639db09c0a50cf6e44cf399bc1028f"
+checksum = "e4482e691c61ea7d68d09a0d3221a2223b36118874c1923a3733a0ff1a9d4a65"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2f9df9cbcba5c986e8abb00dc6184cacebcd96064f706bbd47c870255fa4f1"
+checksum = "3413d41515d5679fa680f96ceac185ede18ac22002837216c9fab863d4a367b7"
 dependencies = [
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6beb51686baee78fc838861b825c1b8f1b66a7633dc502dc70da491aed82dcbb"
+checksum = "63024f2e3aee907a345db4993982b0a853cc330e487d0b7aa2b63bf956bb2a04"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e41c45a18b5e71b05fd5789b210ce79dbddd454e9bc783dd188790be99d91"
+checksum = "4b59201c3a7fad2acc3623e0e933359588e86ba6445ec4e2ced9a56cbc150658"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c771c379dfa58623a6d88d021c7cebe1f9f4f4537155917f7a9c03b5b36c3ec"
+checksum = "859266edee477b8d7c8f07bbe48956f2d0093b7a7466b473df66e6de4dd59445"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b75dd0463b1ac775e8d154879e174e06fb8745b0896b8d9a3bd99d57135e914"
+checksum = "81babd3f9b3af66f27f7af6dfdea1943d16598630c5f4eda34ec56bdb7185dbd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d889d1ab1f8c78dddbe5aa107ae0004f066a79384af010e58539a71c84cbe1"
+checksum = "6d72c43d36e246e388b911ce85176962eeaf7893acb472fe1c4377c7007f886d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd58fa73c9e498414c9e6757f5ff1dbb81b9c7439231018c19aca99c35fd35b"
+checksum = "55cf3baf644a42f0520f030e91e24c72e3d6691f7abc347345219b2e744fc835"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe22ce913c1862862a7ce3180b1a52b544a04a629b92c6dff43c3975ee89d39"
+checksum = "02f6cdaa2b8423f910e260b93065b8c63c7ebbc21c288419bc7a9aa0ed7a14fa"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3d75a9319f7bcb58920ecc087aa246cc4cac0bcf5c9f29bb44260315961db"
+checksum = "4957a1571ca0a761520942623d7d1ff71f2831edfc2f2fc43ad454682e50ad95"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f73f50b2cfeb31dad13e3bd628245bf9f2d8edc98ba3c7591c2f3303304a185"
+checksum = "c9317c665f1692637b3ede02fef4153ae3c4a4fb4b196bbea07a6a011546ab74"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e763dbe561c25187466eabb92d6193ad6098fb656a0dc807ebefbb237f903171"
+checksum = "c1edc38d7ba687163bdf2562b1fd8d440d63648c193b6c9e899ea12a607747ed"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a563a0a45f55c747819f1220adc27e492c5c7040e3a4f597d6e0e959f9742aa1"
+checksum = "ebd63c332aa3c111d10268c29aa439180d4b94c8adecbf526f0a04aeea46bea1"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce49d48a75a006539583808e526d303a09afd8621d3351ad52f8a4ca62fe8a8"
+checksum = "e3980bcda50ec619f93dbb8b73f824413ee5dccabe3511fca4454c49857c1483"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621a7fe9a24a3f69cbb14b06c94894b81ad0aa549dbfff178c9236876cf5a892"
+checksum = "0d02ba6a9a9c27685404f979534ab254f0cda028857ebdb19f7cb9aa0f52bc6b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2c55d655bb56fb48c12fa98f1b6ea292ff58a0cf791cc7c180bb77ea73ac83"
+checksum = "de8b5190c4421f6550504bd1753f82492c28cda5b1ccb6c2759494cdfa431207"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -6652,206 +7001,225 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-parameters"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8bc500ff1d3292950a7d1b50b0e26f7cd9f886cd4a577883267d36a1da1361"
+dependencies = [
+ "docify",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28de923b335df5fc38c9e0b565230120184f5e195624a386cd9bec90fda4b55"
+checksum = "a20718f6531ad2adf84ed0b1f845f29e29987b7fd1ccb738134c60e77177f1d0"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d02c265142821c0144336d6724ec1fc56ddf333837f5ab502798fab5a447e"
+checksum = "a73160cf5aa5ebf1f07eb1134328b272ab16070028c8c1ee9f800ffa3a5c03db"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6a4587dc3f5438631db3c2ec019f31723c4a7949cf63945f111b6c509d0a97"
+checksum = "082ef6517f3901106bc642a7bb35b9c8345cbe55c5c60dbf6b09081b2e3c5695"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2320f4d3b35c47180c80a6ea560d25e491d5812486c8691bdd297b5425f11b"
+checksum = "06afe44a0484ad3c8b943c555fe4d7ccc9da3b3cd1093ddb6a8984bae6f130f4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5abb788c5e8e7960820288caa043f5d037a63248453d493e617a2445790a4"
+checksum = "6b6c4f5bc65be570a065907239d3215036d3e29edbd0ea5c6cd01246e2ba3959"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd630721c9f07bdf90e4cade8f825d1842af9f68f470de186087a3d1f0090970"
+checksum = "2e4b63ec79ab485d54cf79fd5ef574bb7f8f4e094e4a7d11b012a820d4324b62"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fac215d9cf301396720219c4d04e4fe7fcf44d14d4be71f9c3ae3df3cead74"
+checksum = "7570e307118a4663dd3a1d1c949f84a169ef932666e69f7fcf4357781c8c1a4e"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061827f23d4a702a2e159ff84286a0a89488615c31ad05a9af7cc93a57e2b441"
+checksum = "925f793adb1d53c05233ffd2644ca37890d56c9716475108b975969a445d10b3"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
- "sp-state-machine",
+ "sp-staking 31.0.0",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817dd673f7d0b965639d27def260f7ff7a1535f2c5016a611445a8e4dedcf5cd"
+checksum = "ca61297e13c15fef1e4d3b7f2884e70c772be3a9448977ba23954e2c4bcea4bd"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand",
- "sp-runtime",
+ "rand 0.8.5",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a89d24f9a15ae30d56fb9de190200d43735f4c055dcbe1c1259d3d4219da42a"
+checksum = "8584534df25227dd43d80803ea1978af55bf70aad5aa57c83dc3de883b1f1c73"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8ab61dc6b74c79ad396732c1850dafa89109b749b2b651a1d4f20f45f596a3"
+checksum = "f68e48f3d79e0cbb9462eacc0c85c80003924124a893465047f159278338036d"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6859,10 +7227,10 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 35.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
@@ -6890,66 +7258,66 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8792b235b42d70e177301cd7e2e2b1afc828f1a6ddfa0639c481cd0c125078"
+checksum = "c431ab74db8258b39fe829fb7345d38064ef7fb1ce2014b074f586303d7dee67"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 31.0.0",
+ "sp-staking 31.0.0",
 ]
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3e2b1355eb2e08c2de3b14b175decf8ed49bf50de6cc44f97279257c325694"
+checksum = "9db0ce6ccf9e1d2fe2d0b26cecce995e4b095b31bbf9f0492024fbfd4924961a"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdecbca3760e93bb757313495ca7d2437e6141e728a2d266a85884c43d74c0e"
+checksum = "10ee43e8bb38a50a234ef49198413483562e229ca20d8e9d9f78b756244f6d7c"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196720afcbee2f2fd1acfed5a667cffb3914d1311b36adb4d1a3a67d7010e2a5"
+checksum = "5982a7cc371e2b9be504465bb6e47bc27dba0b98ee9794d7fc797c24244fb6d9"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -6957,21 +7325,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3c596b6fb68e70f890436d212af74d19154be438ae0255e5ddeea10e5ec91a"
+checksum = "84e0d02dcd034cb57cb25f1301c6e6c43b8191b96b049e7d013564aaf5d3c6af"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -6981,159 +7349,176 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dedf412abd258989da4a26946f7e480c4335ffc837baef4ef21ba91cd56ba8ee"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-transaction-payment"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
+dependencies = [
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95122a5483521f5186a008326514e5a579931cc1d36980bbca5bb2b566ca334f"
+checksum = "46ba896951ef39011e27d0a91b565520636f926f01b1c912a411146af079ef5e"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4686402973e542eb83da077b46641643834220fbae74a98bcffa762d99e91"
+checksum = "f274055d2c61888689889d6e9b9266b163e1ed298967b55bf961db26b11a60fe"
 dependencies = [
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac957446c936a57417ff7a4866f3463f7f2f49d9bb2daed81093c2de8f0cceaf"
+checksum = "23a11166748c80a432c52d5cc99c2b0e1d2b88592e0ad71eec7cb9f360e375c7"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d770b7c961afe12adc5a727a5d02b44ef09ce38d1dd5923793b3e52e5afde3c"
+checksum = "eb1c70a4abf287304214b16d9eb88f13c991bd696f9e5318fc68e74df9802037"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ce37af22cc31883dfdafa334c4e1f7cea8f2d4fb964f3aa88d77d5eea7ba94"
+checksum = "d9a5b229675f299af7aa40749c579570dce4ab19739779a45f5a87da118af8ef"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f118e773504b4160eb199d5504d3351d360e9ba64197d72384ee0c5ce1c0e1"
+checksum = "249172db9f2b014a6e9d4b5c6d663bcbcb0055c1c2c7564e7bd0488ecb1f15b8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649a096b0c178cb81b0e11fac4d2c67eda7cdae949d2a4c7ef693d2b39d677c6"
+checksum = "db9e654cf90682370fe20a04904cb02df993c3b0dcfad861abcf2811f4fa6085"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14af05792aec4a80c211f029ddc370cc3b0d2153f8adbbb0982d637768837bf0"
+checksum = "60b7038af027fcce5ba3d2f99b941fb997a5556f1fa0b8a7e7e23a448be1bb85"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
 ]
 
 [[package]]
@@ -7151,7 +7536,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7179,16 +7564,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
- "staging-xcm",
+ "staging-xcm 12.0.0",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -7207,10 +7592,12 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
- "frame-benchmarking",
+ "docify",
+ "frame-benchmarking 33.0.0",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-metadata-hash-extension",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7218,56 +7605,56 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "parachains-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e035fedfe5e0a6b4de6d29c56f8ed5ca64f421a883e7e5bcdc37a76a7c715"
+checksum = "43acd23527a3471b1c596b809591edf78d6113bba172fff4a96412d560dfea59"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7276,12 +7663,12 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "substrate-wasm-builder",
 ]
 
@@ -7292,7 +7679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -7313,7 +7700,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "siphasher",
  "snap",
  "winapi",
@@ -7594,9 +7981,9 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9022a11f7a24b293242c08357ab90ca725b9a9153489fae32425ff8d43401dee"
+checksum = "3910a07cda88fd7e19c053f2fdfdb3296c8d55c033a71a642e531faa6029b9d2"
 dependencies = [
  "bitvec",
  "futures",
@@ -7609,15 +7996,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bd08d1b8eeaab90585e50da11114827dbbd0fdf1e6e2a417a57dde01b40d8"
+checksum = "1af6a6893b41ec4eae652ca62537694c9fac71f261bec4e8e26ab6ffc21faf78"
 dependencies = [
  "always-assert",
  "futures",
@@ -7626,15 +8013,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74aab8badb2e230830978ea27a34749ec6d0a096ff5c12fb08935f85e7881283"
+checksum = "f67b7867d8ddc0fe39a462dd6fafaf545be013e0a1c404cbd9a8de802ce6df82"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7646,7 +8033,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "schnellru",
  "sp-core",
  "sp-keystore",
@@ -7656,9 +8043,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1366718a28780768e5f2bd00c28445b0d37be21829b071a8b763534411978d81"
+checksum = "e2547ed0976533c8ed1247187dde1663fdbe5ab366efaae80085bb4b8b410e21"
 dependencies = [
  "async-trait",
  "fatality",
@@ -7670,7 +8057,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "thiserror",
@@ -7680,9 +8067,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cbe8ee58650efc6a414c940e0bc09462926cfa806ace62207297f6a78c65a7"
+checksum = "ce323170edf8a3bb2cb6c2499642e44b8d0dccd60b3b20f9e2b9d776d53302e9"
 dependencies = [
  "cfg-if",
  "clap",
@@ -7699,20 +8086,19 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-build-script-utils",
  "thiserror",
- "try-runtime-cli",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdade551b33b767772d5bca1e19e4b8ea3dadb0154401dac2e578d9f73889d55"
+checksum = "87729af58fda6bccdcf0258d6657ed9150a7f1fc31b3f22fa22dbdd57e1f4f59"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7725,7 +8111,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -7740,15 +8126,28 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3c192d31bad69f561437549b3619a6cf02eae51d7f331efef7cfc6a56d61c2"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c223fda0baf1414d963922e555001b32f6c13308b8b47081fa75959933cf2c"
+checksum = "a67943660c3f3b0ee6f05b42c0efbf1db282f5da18552a44769d3578209c5eba"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7764,7 +8163,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -7772,24 +8171,24 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf840ff7a6337715e20e1afd76fd20dae11ebb049d89855ee2bf47b36b0e6249"
+checksum = "ec005dad44aeca9a315e182039a7c28d08fb57822073685dd1a0bb7827993fcb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie",
+ "sp-trie 34.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477f94e8c3eedd6cfcfdfe50a33d610d38dfec4668ff7f3baef8814ffb7da85e"
+checksum = "85eb9555f3801a69e01c9559327b65e9b8e2532f45d739648e398bba52fbe50f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7797,11 +8196,11 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -7810,9 +8209,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bada301d390179f38d18f10435412c81f35fc8f6e357ed84516ca0018f8c6e21"
+checksum = "c5be1ffa029e0c3eddb50041a13c9ff3d66554effb63aaf78c61c2b10baf9b1c"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7834,9 +8233,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81555b3a87382c8a7c5660b0b8a09dfd2573615086e7351ef95475a17e76b2d"
+checksum = "6efbc62e46127f70a0502dfe5c3f058166425e62c67227028f87a4fb908ba06e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7853,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e3f49e8102d9a0b20f6f96199040ea253708b34bd30e679481228ebf76ab23"
+checksum = "15fc22bda776143d65bece22258364fa84d813164b742bc228877fa8871a1329"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7871,25 +8270,25 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6fe8e8eaf3e368e93a24309d812bc1e5f91fe865a80c1c7cd182fe217c50a7"
+checksum = "52df6f52e1e4a87b52c98b191cf37f14bf0c85fb73c792a10d86d4c9884170ed"
 dependencies = [
  "bitvec",
  "futures",
@@ -7910,9 +8309,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5417cf48b5948ed665f847240135f1fa5415cc5d3e9013cc3140a632cbf156"
+checksum = "8785e8abeef80825f48f581b34386ec92e4d4edb78256836a5723f7c2a33003d"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7931,9 +8330,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2365e3ddb8073f54e81b222e51a364cd3e38b7371bcd042017b73db2d523028"
+checksum = "d5855878573327e0975457dfea64b94081254ccd27ed32db19e2c3e9c11da832"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7947,9 +8346,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867b7c560556d063b4b93d0cec3a5f6932735311b5d66666105705b87fc36a9c"
+checksum = "87bef20a6df020d75b2750ac2b7926e17305588508f2ecafcf486f104145b337"
 dependencies = [
  "async-trait",
  "futures",
@@ -7961,7 +8360,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -7969,9 +8368,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ffcc24bbbc2a2523c599022b106f0b48213bf80ef75f490fe02ec79ab972e4"
+checksum = "e7f0c8062fd9dcae3ca07ef32881e796979d7171187de3cecddc128bb03740fd"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7984,9 +8383,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9971f3ef6226f6f12bede58e009aae16fc6fc636159ec1dc7f1add2bad87638"
+checksum = "77d6f7ea52ddafcc80371a6e619e7c2247f1e2373b97180397ff832bd5a49d89"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8002,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d839dc81ec2f6593fb33bfc4d0e469c56ee0953fd129cc10fe224f7f2ff0bd"
+checksum = "aeb9022aa49a3cfaf5c452dcfb41f13511599409e569be527b229c3a94311b1f"
 dependencies = [
  "fatality",
  "futures",
@@ -8022,9 +8421,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3f8faa7a013b08ebdf4e018b8f7daccfc2b13fdac154d361ceb5be9992647b"
+checksum = "651b0dcf8d948b80c1980ccd973a7e3d666f30c74762a4f2b3b2312754936337"
 dependencies = [
  "async-trait",
  "futures",
@@ -8033,16 +8432,16 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5995f6998c35e9bbb8ab784714fcab7c9ddc6f0125cbd99a7175674a3f99f187"
+checksum = "e908f038f83eb28bf1ed586bb3bafb59907d1aebe0ae5ebdb4892a88eee1982b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8058,9 +8457,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccd98d226f1a650827183e6807466d0569691dd4a8434a3974eea041c73a677"
+checksum = "0dd8237ae0bba201d668f24aa574ffdebcc4af6ed265aa924b2ff99680a04eb7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8077,9 +8476,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db5f945f8f26982b46c5cb1ed9c37f29d7e851bd06dae97b2b04e6d46dd4b77"
+checksum = "5987cd5501271b74a95664ee7f5ad1bd8e96c95b8c8bb7ca843b264ef5b086b5"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -8087,22 +8486,18 @@ dependencies = [
  "cfg-if",
  "futures",
  "futures-timer",
- "is_executable",
- "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 12.0.0",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "slotmap",
  "sp-core",
- "sp-maybe-compressed-blob",
- "sp-wasm-interface",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8111,9 +8506,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275cab7ad2b38fdfb0c097485fe4f51e55e36c96330255edc38ccf121aa2171c"
+checksum = "dacfc74431199c07b35dcf1710fc800d158cb28bcc2e896d0dc2fa696cf08254"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8128,18 +8523,17 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1cf57c2204d9f80da258cfd1ca8e2ef7f366fa7810333da5f8519a05ba574d"
+checksum = "c9f5c0302abddbd120abfab4cf9de2794ac2aed3554d2741b0dfa79962595b22"
 dependencies = [
- "cfg-if",
  "cpu-time",
  "futures",
  "landlock",
  "libc",
  "nix 0.27.1",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
@@ -8148,7 +8542,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8156,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9c685da442b6dde17f0f1e4bd6bb4d6827c6af0dbe96bc603d3d4f8fd05953"
+checksum = "581aab355ba6d81e05753f8fa401c928ddcda8d553dec4450abbc330956525fa"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8172,9 +8566,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbefc5402f4eadf6dc976d8013c0e050947809a1442a6fc3c44640841c7df712"
+checksum = "622b0231ea2b17096a69dcfb1a62ecb64ca3fcd91830efed0bf25c6b311c1eb8"
 dependencies = [
  "lazy_static",
  "log",
@@ -8184,6 +8578,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
+ "sc-network-types",
  "sp-core",
  "thiserror",
  "tokio",
@@ -8191,9 +8586,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba41f6bbcb2261a92c452ffa2960301079a0922c832491b4e9aa3400887e33ac"
+checksum = "0cc571e16a460fb03319a17d037facb4924f549810e1fcacefbebc2c4cd2e3ee"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -8211,9 +8606,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915df9a38d99dc98216f8dce9a90f3ff2cee0d7fdf9b956c055844421b0d231b"
+checksum = "2761c570ac12f5dc48534cc39512118ecbfeb04116fdff5c4c79cf85263a1ab3"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8226,9 +8621,11 @@ dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
+ "sc-network-types",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8236,33 +8633,33 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8d9fa95f0752c64635b2c8fc8c39b55eedb960f18a068d10720085c8ad06f6"
+checksum = "4e862d29bcc6b6d76ea41a08627edddb1f1fa071821019462f07e3bf53801336"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5bbd86b3014ce7cc71e1a90bf641e26c4cea98955522d350268efa97c58de9"
+checksum = "bab90aceb1e00cb2eff617785f4bc8a40501f525359fb718d2c9ea5b90427d66"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8271,9 +8668,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca25de72c086250c6b53ba0a868fcb1c99c305e0abbf5e3faf5568310dd4672b"
+checksum = "c2973a2b608b792adc4a042f9d06d4eebfd63a05557c35bdd5040f445e26a680"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8287,22 +8684,23 @@ dependencies = [
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61ee42f50de06ae2d0209cb49af9805b780d1042a49f74f9841d2095784827"
+checksum = "d30298b2d686e24684754a5236fb8986c7c1777f8695ee81c61f5c69a891ef36"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8324,10 +8722,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8336,9 +8734,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa9663b506f2c6632468e1207e4a651ca16f2f4aba17d0a3d9e2fb828f02c5"
+checksum = "e5b0505f383fb8d474cef23cc1a8e24617cd9fd17ee44bbd13f5f92f98de53d9"
 dependencies = [
  "async-trait",
  "futures",
@@ -8351,7 +8749,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
@@ -8366,48 +8764,66 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 11.0.0",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-parachain-primitives"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549ecbe3c247ca2201e231801111ff4739fb1d66eb1421c2e5c0a2b153ac87b5"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "parity-scale-codec",
+ "polkadot-core-primitives 12.0.0",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71eabc294df35faa0877f6427e9a37d3b8323922aa0372cc9208e492d8f1b2f5"
+checksum = "ae78f3443b86249d5f7756177984d6b3c6b1af9432ff2a48e299be2c6ab97297"
 dependencies = [
  "bitvec",
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 12.0.0",
+ "polkadot-parachain-primitives 11.0.0",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb29231d3184c38d011a7bffea09a2c1724b5d7544d43d6159aaa3870ae74e26"
+checksum = "b791f93e89c38bafc894e9364c27a85b8d5696a9280f95f22c39a601cae4e6c8"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8426,35 +8842,35 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c9469b179e1bef848bbf051df1bd529b2b9a2a0428c0f87527586a5bca3848"
+checksum = "3effc5cafb231ede1c394abce9575c292e95170e11ee1ecc5644d25cf35b54b9"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -8463,7 +8879,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -8474,29 +8890,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c04cc730f9ddcd9a663eddb95915d783704d11ea12eb2882c0abe18968b9de"
+checksum = "6cfaa021e4639e9fcba7c40111d93720b82cea98d667889760e46a40137e3d47"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -8505,22 +8921,22 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32edd5b366f1e45995f613997ed259993cd2746f0407f186136696d54e24d784"
+checksum = "7b9f30223690133e9fbede03615c6b88aeaa774f777067d2253057ef35ba0270"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -8528,42 +8944,43 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 12.0.0",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f276b38deaab6bff3ddfe061331901196ff992f76398bd0abc78382f4f115cf0"
+checksum = "fc6acbf05debbbab4831318fdbe0619742573dda47721af7e2ff042def2ec77a"
 dependencies = [
  "async-trait",
- "frame-benchmarking",
+ "bitvec",
+ "frame-benchmarking 33.0.0",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -8574,7 +8991,7 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -8584,7 +9001,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 12.0.0",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -8609,12 +9026,13 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
+ "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",
@@ -8641,7 +9059,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -8650,21 +9068,21 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 34.0.0",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 12.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
@@ -8674,9 +9092,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded486e00b2d5bdc589b4b75c722d7a2b2f4669bd3b492227d3501d60db1b4ec"
+checksum = "ca1a7eff92a348821650ed63e02c28a7ee2b5a76ef12d8289882a1e6f2e7de90"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -8691,16 +9109,16 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking",
+ "sp-staking 31.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc9894c6ae63eb4ba1724cc4859db2224038b770b3ac1bf05f0650cbf01dca7"
+checksum = "4b879ec2b27bde2a05b70bd4826d7785c1e01ef72fc4a058d1055b1c95f8deb6"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9193,13 +9611,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
+dependencies = [
+ "bytes",
+ "pin-project-lite 0.2.14",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
 name = "quinn-proto"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.9",
@@ -9208,6 +9644,19 @@ dependencies = [
  "tinyvec",
  "tracing",
  "webpki",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+dependencies = [
+ "libc",
+ "quinn-proto",
+ "socket2 0.4.10",
+ "tracing",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -9224,6 +9673,19 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
 
 [[package]]
 name = "rand"
@@ -9281,7 +9743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -9550,15 +10021,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1a30be097c0e02d2aacc4b2b73ecba2c795ae9246f2c37711ebae0e69dd95c"
+checksum = "224e7b002c0ba04bcee4bf25e2d90ff1895a9c1171fd8c3162c63a558c33a0d4"
 dependencies = [
  "binary-merkle-tree",
- "frame-benchmarking",
+ "bitvec",
+ "frame-benchmarking 33.0.0",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -9568,7 +10040,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -9586,6 +10058,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-nis",
  "pallet-offences",
+ "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-ranked-collective",
@@ -9600,7 +10073,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -9609,7 +10082,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -9617,29 +10090,31 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
+ "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "sp-version 34.0.0",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-fee-payment-runtime-api",
@@ -9647,19 +10122,19 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa26847ef6b32b5fd41d4f86538ef15b8d74f208d211644dc14e4dda74559116"
+checksum = "578bde81aeca421df7d898726f0d3d9caea11eed87d77760be71177ce071977f"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
 ]
 
 [[package]]
@@ -9956,9 +10431,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cd4cf9f2f6a12f1cc042831474f33103aad8ebf9fa6d49f7119521ed89b1ec"
+checksum = "4e4f35b9a8b91dd1232a26041c064d57b9f03ad2b80d2912512cfd1e4851e506"
 dependencies = [
  "async-trait",
  "futures",
@@ -9967,29 +10442,30 @@ dependencies = [
  "libp2p",
  "linked_hash_set",
  "log",
- "multihash 0.18.1",
+ "multihash 0.17.0",
  "multihash-codetable",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
- "sp-api",
+ "sc-network-types",
+ "sp-api 31.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2354138e44624d68245b9490c0d30f73bac7c00f218643ff03fc0dbd1536b98"
+checksum = "0f71eb27c36bb0cda3e67f1e0c4c45ced6672ad4c47148da6bc7fd729e99865a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9999,36 +10475,36 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d54ed880c04f6df650dcf4672d7d4a2d08b30e95c51f07b4a3be75eaa535082"
+checksum = "4190e69ccdf1b10c530e110345d67c6347aa0bc03fa56723103d834fb8ac907d"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d25ff00e77262342bd85a71de32170b136773f6a8cdd5641ce8b81fb4e16be"
+checksum = "a3256a5e3294dc363ddb17ac3040c33b9848269dd288eaf8ac6a2972f8a1d884"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -10045,10 +10521,11 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.12.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -10065,9 +10542,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eade6864cba8ab29c4c7572c6a4a080c0423bc53cb48b00f70eef7d57d22abae"
+checksum = "397091529b095369e8b9342a0dcb732bf6ec672b4be9db76b5174951618f541a"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -10080,7 +10557,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10099,17 +10576,17 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f69c592a2cab8b5cb7860bf57c5084a590d2e0c5df9308f62ddb405ca4d97e"
+checksum = "cec1bf37389619d861680f7da315ac5a815e5cd924ec9a0adb86e4ba4aac7c99"
 dependencies = [
  "fnv",
  "futures",
@@ -10119,25 +10596,25 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "sp-statement-store",
  "sp-storage",
- "sp-trie",
+ "sp-trie 34.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e8c9db1025f0b17438f5db8937c53022b417593f30d4624b8b2e0d3300b9f"
+checksum = "ffe19e497ab77b89efa4e2b885af725d6ed59579ebe8df96b820f5b122c10da9"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10155,42 +10632,42 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a051ffa28788f7ec47e46d6236132126d5aa563469e6c852e87cfbe5069e0687"
+checksum = "0178e3ef8d317456e352466a9c5d3b6d9b5861a64b43c01ab62435e24fc68a51"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity",
  "log",
  "mockall",
  "parking_lot 0.12.2",
  "sc-client-api",
+ "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd537650a8f23d6775456a5a06e1cf27722fedc5515769983e18ef856a6aad3"
+checksum = "be48cd2fa20a6800595f7f49dbc929ad72348673c38eb7faa072cb8dfd7b47ce"
 dependencies = [
  "async-trait",
  "futures",
@@ -10201,26 +10678,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe6f127a27ea6ace8e4391ba847ccf21d3512499e1c5e7c300e7e5115642544"
+checksum = "08d58429c3660dfb86b9c0a1529dbc444f1ba8c8135812468497751d5b2567d6"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10237,8 +10714,8 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10246,18 +10723,18 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents",
+ "sp-inherents 31.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93183245d51eab164ab5513f5ad723964c38f293427d99066f8aed02ae715e1"
+checksum = "cd3bd3762945244a50e7e64aa9302405ba3d225a807872a4f99e8250e5ec4e60"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10265,22 +10742,22 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f0cdd776453ce7d73fdb548648bdfefdac6c497d198083222aa0d7636445ed"
+checksum = "0f0f27e60a0a3135c991e26883c4827f8bb3fa082ee84690544eea9040d0edf8"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10295,9 +10772,10 @@ dependencies = [
  "sc-network",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10306,7 +10784,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10315,9 +10793,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8193f51766e9bf5a94f044333f4807918f7243eab404e9ff91b98ba268f2e9"
+checksum = "7db1d87a1107de282b3208e25370c1f54dcfc9f0c12bdea52fad127df4929c63"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10329,29 +10807,29 @@ dependencies = [
  "serde",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2217e53886dbfd4749eaa2e671f8e59807a2fb711ffa0023b3dc5b30f5db458"
+checksum = "e7d878112bf0e7b267eb753e9a43432616dc190f85be921bc03d13c42a7c21bd"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d666c23af4325c6d2ca35bfe2874917f5dfdd94bfca165ad89b92191489e2d8"
+checksum = "4ba0980a68efdb28cba1a8051dd27d104258870f16287df9d576caf36add3ebc"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.3",
@@ -10364,7 +10842,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -10373,12 +10851,13 @@ dependencies = [
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
+ "sc-network-types",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10386,16 +10865,16 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ff3f1dc9c74563e559725736e07f4817e3429cdfd593e4a8c583d2c8da0894"
+checksum = "5c587c6b017281f2029a7901de1e2f6f85ee8b365e9d15b159a5c44450fc71f6"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10408,15 +10887,15 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80382f4da8a76c05c23b84d5c369bb5d617d499749171335e9b47599885fb202"
+checksum = "b755082e44000f02660697560c279d81cea4ea984d5a21eb27a2179c92912fbc"
 dependencies = [
  "async-trait",
  "futures",
@@ -10431,16 +10910,16 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b47b642a92adcabaeadb7d76bd1a02bcf5a93f2b649e81afe8b940107bbda"
+checksum = "5d0738d2e654f8cadb8b5b5f64c281654838202bf77641656b7fe2bd5346a25b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
@@ -10448,14 +10927,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-externalities",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -10507,9 +10986,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061006dce0dcae3ece90d5d9f656ade507dd922931911d59deea823f28be54dd"
+checksum = "4bb38b9ee63b01ed966f67789684b517cdc7891c0ac30ddac0e039695a43ab03"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10520,19 +10999,19 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6477f27aa17ada189355325c16992d3e612d2fe276ecef9da1b36b6b297b3ac4"
+checksum = "8dbafebe46cb7a380d6a1a77c045af06de3cf92ffcb5bbbbb1567e3b0c94d688"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.2",
  "serde_json",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -10540,9 +11019,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e04fecf6e55e4597e473c87e8f3cea5a9963835af30a971203290d62bb2d03"
+checksum = "3c48f0897bac630c7f58e0e8f5b5930db18641ac5c0df6fcca0335520c1be74a"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -10550,7 +11029,6 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity",
  "log",
  "mixnet",
  "multiaddr",
@@ -10558,27 +11036,29 @@ dependencies = [
  "parking_lot 0.12.2",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e68214c9245ee374a6c51fca3c00feddbe20a86451d92c76585a9cc9553425"
+checksum = "c94a6131f2c50126601a01d9b60a8df569aa8483cf6754e280b754a5e716a297"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec",
  "bytes",
+ "cid 0.9.0",
  "either",
  "fnv",
  "futures",
@@ -10586,58 +11066,44 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
+ "litep2p",
  "log",
  "mockall",
+ "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "partial_sort",
  "pin-project",
- "rand",
+ "prost 0.11.9",
+ "prost-build",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
+ "schnellru",
  "serde",
  "serde_json",
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
  "tokio-stream",
  "unsigned-varint",
+ "void",
  "wasm-timer",
  "zeroize",
 ]
 
 [[package]]
-name = "sc-network-bitswap"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7cf01e661f39303737596859139fcdd31bd106a979fae0828f3e5b0decce89"
-dependencies = [
- "async-channel 1.9.0",
- "cid",
- "futures",
- "libp2p-identity",
- "log",
- "prost 0.12.6",
- "prost-build",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-runtime",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
 name = "sc-network-common"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b1732616f6fd5bcdabd44eac79b466c2075f3f47ebf0cf2f6d52d790890736"
+checksum = "ae304be8447d6101c7d314932137ff2405db43bc7daf4b9c0c52341bdc9265ac"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -10646,16 +11112,17 @@ dependencies = [
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
+ "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb8b10666371dc53bd9e11dbb99e0763307203ecc70f4d9bb20169cf7ad69db"
+checksum = "ed5317c3a30c77978ef7cfb2655e4dae2f7ba82df1622b6b6e81c854c19ffb43"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -10665,39 +11132,40 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be9c7b3d18d5ef3ed493be173e9cb00537585cd9b21bb4ebe24b9b555cf4fa4"
+checksum = "10a2b0e0c87d74704a758be2d3119bbbf652910b3de0d3074864531f2e1afd3c"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "futures",
- "libp2p-identity",
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
  "sc-client-api",
  "sc-network",
+ "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8a240043ecd1c5ca54d1dfdc654878aed6b96fe7292c11dc9e8bc7c4884fb"
+checksum = "92d3a03c11fd5ed3c596a055d79596e6c0d7ea5166b627346e0381adde49dd50"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10715,6 +11183,7 @@ dependencies = [
  "sc-consensus",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -10723,7 +11192,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10732,9 +11201,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1514ca1cc195842970b3a35b80cc14ed002296f3565c19d4659be44ca9255b8"
+checksum = "1f8586ce7e34e555021b574ec98c4d459cc46625f1d061a3ed8bea6a400e8648"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10744,17 +11213,33 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
+ "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
-name = "sc-offchain"
-version = "33.0.0"
+name = "sc-network-types"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f289809d0c3fd09474637bfe2dc732f41fb211d1241885194232c5d612a641"
+checksum = "a6b473a65393f65579019e4280cc116848439985c62724db8402bbfa7da462d1"
+dependencies = [
+ "bs58 0.4.0",
+ "libp2p-identity",
+ "litep2p",
+ "multiaddr",
+ "multihash 0.17.0",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-offchain"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb6f76c65abdabfadb497a5fe33733ec67af15221aa1c72686096aed75b28b8"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -10769,18 +11254,19 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "threadpool",
  "tracing",
 ]
@@ -10797,9 +11283,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d7b43d6ce2c57d90dab64a0eab4673158a7a240119fd3ae934ce95f8ad973f"
+checksum = "df3af3898afc9e63bfda6bbb75a20bb66a4b3de0bc077eb1b67d94b04f69b984"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10815,24 +11301,24 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
  "sp-statement-store",
- "sp-version",
+ "sp-version 34.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82060f09f886f59fd19a77cc6668c209e883fc93511e9c441ef84adfea80f36"
+checksum = "2656a0da9ce809fb31dc0517b7e0a4185001785154b59cd9546566f1db8df346"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10844,8 +11330,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
 ]
 
@@ -10870,9 +11356,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad831d2524de44a89b1801e306fd9718dc5fadb26ea3e88f486faa29c6fdd710"
+checksum = "57f2b3d4ad7238f031c85395980f3b05026dba6f596e1e3600274fa9c30974e1"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10882,19 +11368,20 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
  "sc-transaction-pool-api",
  "sc-utils",
+ "schnellru",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 36.0.0",
+ "sp-version 34.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -10902,9 +11389,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff048cda961d13a0978bf6e75b1978c0fa886d2087133a4d2107a034afd27c8"
+checksum = "70d4e550aabcfba3a9e6a2c4e23dcfef362cb62bea2cfc3348879e327482ec72"
 dependencies = [
  "async-trait",
  "directories",
@@ -10916,7 +11403,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -10925,11 +11412,11 @@ dependencies = [
  "sc-informant",
  "sc-keystore",
  "sc-network",
- "sc-network-bitswap",
  "sc-network-common",
  "sc-network-light",
  "sc-network-sync",
  "sc-network-transactions",
+ "sc-network-types",
  "sc-rpc",
  "sc-rpc-server",
  "sc-rpc-spec-v2",
@@ -10942,20 +11429,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -10993,9 +11480,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75577af6d7128f3c0cd1dfa83f9ec056dbe4cdce297f1d257f2a1253134c6e9a"
+checksum = "910d78b0ea4778a639a9d1345d4e5ce27721ed0d717635aded1bb6c522044bb2"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11007,21 +11494,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a838bf3ba61e83c0f3be4a41ba7ed8c71d19c2adee6396046f78317006637b"
+checksum = "985818b31ecd4e04edadbf6124e2b71033551c08ff891bd9449fbddd2346ddf8"
 dependencies = [
  "derive_more",
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -11029,15 +11516,15 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a5a306d8c75e61e8c59e18b92886f85db6b4102c4669240eca101954fec79e"
+checksum = "6a874600f40a5cef2e1482574f7665ed005f7c3b7594f9abddcb2e015651c4d9"
 dependencies = [
  "chrono",
  "futures",
@@ -11045,7 +11532,8 @@ dependencies = [
  "log",
  "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
+ "sc-network",
  "sc-utils",
  "serde",
  "serde_json",
@@ -11055,9 +11543,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e4f81defe03776909ce283429c9cd3d80fea6b2f3a303dc2bdf913e11d9e8"
+checksum = "8c7513573600566bcc7a41153c6a99b628e800acd65bc124c3ac595322324021"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11072,16 +11560,16 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.1.4",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -11098,9 +11586,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54754bf43dede417a8e64a0d6a46bf2bbed47ff050c1f81c8a575f9b94416886"
+checksum = "18f865b689f7f732de5c6129cbdb793d7c71a88ef0d1636d8b843e590d5d766a"
 dependencies = [
  "async-trait",
  "futures",
@@ -11113,11 +11601,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11126,9 +11614,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b563c7257ab650b2639d623da13d1a50a5a6c4ec582bc92e118c73d072bcd4"
+checksum = "618532cf1e4afbc3a3f9046bfb4aaceba46fa9888ec9d1d12e9fe5448aa7ee82"
 dependencies = [
  "async-trait",
  "futures",
@@ -11137,7 +11625,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -11155,6 +11643,29 @@ dependencies = [
  "parking_lot 0.12.2",
  "prometheus",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
 ]
 
 [[package]]
@@ -11182,6 +11693,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -11258,6 +11775,21 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sctp-proto"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f64cef148d3295c730c3cb340b0b252a4d570b1c7d4bf0808f88540b0a888bc"
+dependencies = [
+ "bytes",
+ "crc",
+ "fxhash",
+ "log",
+ "rand 0.8.5",
+ "slab",
+ "thiserror",
 ]
 
 [[package]]
@@ -11431,6 +11963,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+ "sha1-asm",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11439,6 +11983,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -11501,6 +12054,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -11520,6 +12079,15 @@ dependencies = [
  "num-traits",
  "paste",
  "wide",
+]
+
+[[package]]
+name = "simple-dns"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -11551,14 +12119,14 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0e4ae8d02b43620ca7f567ca94fff494d85aecc73ffebda6c8fa19545b1673"
+checksum = "7bb6f55c7308986f519ce3d554f832774e6212b14774e72313a0c1a3591adf5a"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -11630,7 +12198,7 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "ruzstd",
  "schnorrkel 0.10.2",
@@ -11673,7 +12241,7 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.2",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -11740,8 +12308,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
- "sha-1",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
 ]
 
 [[package]]
@@ -11754,16 +12322,39 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro",
+ "sp-api-proc-macro 18.0.0",
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime",
+ "sp-runtime 35.0.0",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b500647cfe266d58781f44af9b13c3bd57fb3be08642f2a9f13e024cc5e22359"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 19.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-metadata-ir",
+ "sp-runtime 36.0.0",
+ "sp-runtime-interface",
+ "sp-state-machine 0.40.0",
+ "sp-std",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
  "thiserror",
 ]
 
@@ -11772,6 +12363,21 @@ name = "sp-api-proc-macro"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681e80c1b259ee71880cd3b4ad2a2d41454596252bd267c3edf4e14552ab40e1"
+dependencies = [
+ "Inflector",
+ "blake2 0.10.6",
+ "expander 2.1.0",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213a4bec1b18bd0750e7b81d11d8276c24f68b53cde83950b00b178ecc9ab24a"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -11792,7 +12398,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
+ "sp-io 34.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57541120624a76379cc993cbb85064a5148957a92da032567e54bce7977f51fc"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-std",
 ]
 
@@ -11814,143 +12434,143 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5700c6f51afc80af2dd2b39973183d7527e8b5be390fa125d777f948db0e88"
+checksum = "6d8494eafd70194198b7fd82446da59380c7346bedf68e83dfbdb5f338395437"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466eaa1fe1745e9456a5e5afc033b67a52211463a137ea3551bff36b4d72ce03"
+checksum = "51cf3d8fb96de98aecdd32cdd4a735af4d84fae274314f411f95c89d4dff6ad3"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed0dc760fde2b2cd07ca9428e3d6b7ecc02bbd00a5dc32b7f829c80889b152b"
+checksum = "488d3cc94c345ce55d1890239bb256f4418f9566e29b7b90f01817bc7b553a08"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.2",
  "schnellru",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19910bc7cd10336a1b13611df1212bce5cabbcfcd92a9394e23476498aa360c7"
+checksum = "3f400a20113301fa91094c210b9b9b63f066cee55f22517768eaadf3519124d8"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67647dc44d2f47f8b96a56f30a896926485e55a8209cfe916cf8d08a6d488f03"
+checksum = "c8904da70720b26f207b6ae1d140cac4f5b10b94bce535e08ee0df08f3a27a84"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3500dd1ceb99ca5e6f399d37c4e42f22fcbb6505e07378791ebe57eec6a1960"
+checksum = "75f99229c382c3f849160da42c897321fd6b82fe685bc0c4ba4afdd51b818bd1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160ad989b247b55fdc2acd8baa7d5a0b9daca5ad0d4fac6e94ee119ed0fdf164"
+checksum = "f5eb094064dd8f1ff03bd92c843c5f979c1b18e955afb5c0ad98f9c781225e12"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 35.0.0",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffc3f88b33c2a8c14f4d05a3c69c5fc7b02cdd3300993a22d6d2175d35447f6"
+checksum = "a6f4d90b65fd82e77c3b8c382c3a9e669bba5ccfb5402a945cde88984c98681b"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dcae1dac6908d80bceaff4f311bc694c3b9c0d3ac6e74128ed4e3a29e9e31f"
+checksum = "60823551c6987e2f5e1dda772140a09850e866e704757662795b8e7cacf9b228"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11985,7 +12605,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "paste",
  "primitive-types",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -12069,8 +12689,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
 dependencies = [
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7605a8ed2c06d348c26055b7907c3d2d62f984666e9025b57df4895f865f5901"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12083,7 +12716,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170537049d57fc645637e4586fe98a3291392b2ecfd7988ea31639cf43470b42"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -12094,7 +12741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44ed47247b6eee76ff703f9fa9f04f99c4104ac1faf629e6d1128e09066b57b"
 dependencies = [
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -12106,22 +12753,49 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.39.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 33.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b64ab18a0e29def6511139a8c45a59c14a846105aab6f9cc653523bd3b81f55"
+dependencies = [
+ "bytes",
+ "ed25519-dalek 2.1.1",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine 0.40.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie 34.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089da5d08c4a6b4a36de664de287f4a391ac338e351a923b79aedfc46162f201"
+checksum = "33d2c495248bd141fe04ec639785c874949b2c552c00ea4afc4c183c654466ce"
 dependencies = [
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "strum 0.26.2",
 ]
 
@@ -12160,57 +12834,57 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ba1e6ceede3aa5e36ee161dc02f1b294a659823887cefc4f0f2fce589e3c11"
+checksum = "2242e7a802822109e007c3d6ee79640f8dc3abee7139d34ce029c7478361be8c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8abf5586785c20bb4bdbc81243877d5bb2bdf6dff6a03c101b6a3a875bc9278"
+checksum = "dedd59967d2f759bec2be705840d170a5dbf38866acaedffe7c813e7547325bf"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f90a3a36f052f4f9aa6f6ab1d59cf6f895f3a939f40dbe1f3e14907a2e31"
+checksum = "8e52344b6fd91289a87c3fca03e5147df178167b150e1a10b82243434f43e134"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50efea44dfc8e40c59e9f9099c6a4f64dc750ad224fd8dbf9aec12fc857fa145"
+checksum = "2cbbd2096fda34c2f6f9f268c808ca280c08565e759309ea24f17dcd0808097b"
 dependencies = [
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12248,14 +12922,39 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
+ "sp-application-crypto 34.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 34.0.0",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 35.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-std",
  "sp-weights",
 ]
@@ -12296,17 +12995,17 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d66f0f2f00e4c520deae07eeab7acf04c1a41dd875c7a4689e4e4302fb89925"
+checksum = "9c558f85486882433adcfdfe05c5e82972a7be1a6d7fa68a6213b70ec1d86068"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
 ]
 
 [[package]]
@@ -12320,7 +13019,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-staking"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd38abe12a12b0c24d318011ec3cd3280f8d828666994695a6c0652f38662dbf"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12333,37 +13046,58 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie",
+ "sp-trie 33.0.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18084cb996c27d5d99a88750e0a8eb4af6870a40df97872a5923e6d293d95fb9"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie 34.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "sp-statement-store"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e22e2d355461e02aa8325a819d24403fb7232a828bf1e21ad8982fde3f0dc0e"
+checksum = "c7ac525ad4b3533aebdd68ae097d0a55887b6499b565c5a592f6c18372a40caf"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -12390,14 +13124,14 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3965ef60cc066fcc01dbcb7837404f40de8ac58f1115e3a3a1d6550575ff6"
+checksum = "bdb7768c895643e315f9bcfacdd61e283b78c862d976fd081a508cf7239c8643"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
  "thiserror",
 ]
 
@@ -12410,32 +13144,32 @@ dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bddae32e6935eedda993b7371b79e69af901a277e11be2bbd6d9bc7643b49cb"
+checksum = "207cb372504cf86237fa63953a0aa40d7596d1c9cf21175a56346ed1744eb8fe"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726f90279766e231ad86f884e5f07d9331852a59d739f27c5f5e28bee0fc6da5"
+checksum = "1141f46e088898986a59c8aae4a91c8d8c04da22a38986a8bdfcb2446889ee5a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 31.0.0",
+ "sp-runtime 36.0.0",
+ "sp-trie 34.0.0",
 ]
 
 [[package]]
@@ -12451,14 +13185,38 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
  "sp-externalities",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87727eced997f14d0f79e3a5186a80e38a9de87f6e9dc0baea5ebf8b7f9d8b66"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "scale-info",
+ "schnellru",
+ "sp-core",
+ "sp-externalities",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
  "trie-root",
 ]
 
@@ -12474,7 +13232,25 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8e3856686aa2719b1c05af07ba7e6021d844944472f246f3b5f1c585be04cd"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -12533,17 +13309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spinners"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
-dependencies = [
- "lazy_static",
- "maplit",
- "strum 0.24.1",
-]
-
-[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12585,16 +13350,16 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1383aa763f2cea1a816761948bfc1245040740d418c6b77d36fd4f259b944d84"
+checksum = "4efd2f6285b97c1797f8451afb9834a90bd7b90712e6d1a3df8f68f9e7357ea6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-std",
 ]
 
@@ -12614,7 +13379,26 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-weights",
- "xcm-procedural",
+ "xcm-procedural 8.0.0",
+]
+
+[[package]]
+name = "staging-xcm"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5090e0801a8aeb28ff88cc6e0ca0bad399cc58eed11ec70c517fcb316bd3151b"
+dependencies = [
+ "array-bytes 6.2.3",
+ "bounded-collections",
+ "derivative",
+ "environmental",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-weights",
+ "xcm-procedural 9.0.0",
 ]
 
 [[package]]
@@ -12623,21 +13407,44 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0681b0a478c2f5e1f1ae9b7e8e4970d79ec8ef94f4efebc011ea335822bc264e"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 32.0.0",
+ "frame-system 32.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 32.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 10.0.0",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 11.0.0",
+ "staging-xcm-executor 11.0.0",
+]
+
+[[package]]
+name = "staging-xcm-builder"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
+dependencies = [
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-transaction-payment 33.0.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives 11.0.0",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-weights",
+ "staging-xcm 12.0.0",
+ "staging-xcm-executor 12.0.0",
 ]
 
 [[package]]
@@ -12647,19 +13454,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb518e82e9982c90c32b66263642385fc186c76f329766884d3360b65e84dd46"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
+ "frame-benchmarking 32.0.0",
+ "frame-support 32.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 11.0.0",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-weights",
+ "staging-xcm 12.0.0",
 ]
 
 [[package]]
@@ -12697,6 +13526,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "str0m"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48572247f422dcbe68630c973f8296fbd5157119cd36a3223e48bf83d47727"
+dependencies = [
+ "combine",
+ "crc",
+ "hmac 0.12.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rand 0.8.5",
+ "sctp-proto",
+ "serde",
+ "sha-1 0.10.1",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "strobe-rs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12720,9 +13569,6 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
 
 [[package]]
 name = "strum"
@@ -12780,9 +13626,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949d14f7bb2a53b77985bd17a8eb2e9edf8d5bbf4409e9acb036fa3bf7310d8f"
+checksum = "d19975c2965833aed97064cd34975ed5bc0390e4436c84b381874c8abce43712"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12791,11 +13637,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
 ]
 
 [[package]]
@@ -12812,24 +13658,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-rpc-client"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812076602836d6d90242c431729814c790c49685d142f47ec41f3b897a5fb6ad"
-dependencies = [
- "async-trait",
- "jsonrpsee",
- "log",
- "sc-rpc-api",
- "serde",
- "sp-runtime",
-]
-
-[[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da2e823fb02fbd5c77d6949cde60ff3e320c100278818000b39e9f0a8c8c428"
+checksum = "538029eeb26c9ab3f5f8677d696336f92ee536918f4e7ba7fcad1d08ad31ca6b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12837,25 +13669,34 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
- "trie-db",
+ "sp-runtime 36.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-trie 34.0.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "21.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a7c3e61041eaa76a89ded469f84d243fb34557ba4ee1e60335e65c8b5540c9"
+checksum = "6567b61eca9459dbe71385caef9f6eab826abbd4a0743abf27034d96d34b9062"
 dependencies = [
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io 35.0.0",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version 34.0.0",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.13",
@@ -13170,17 +14011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13211,6 +14041,21 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite",
 ]
 
 [[package]]
@@ -13382,9 +14227,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48057e9b12f413d8d104aeb84d6efad65e8bd325acbfa91f7f97724bcf1dd2ed"
+checksum = "d037e38c3da801f670c99e555882a8009c40a8a473815e6a4ea72a8e2887c0c4"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13417,6 +14262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13435,8 +14291,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
- "parking_lot 0.11.2",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -13445,8 +14300,27 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers 0.1.0",
+ "nu-ansi-term",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -13457,6 +14331,18 @@ checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
+dependencies = [
+ "hash-db",
  "log",
  "rustc-hex",
  "smallvec",
@@ -13480,16 +14366,41 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -13514,7 +14425,28 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -13524,47 +14456,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "try-runtime-cli"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45904e10377e9973238ae9e52bd0fbbb0bba5d7be9198458ba9d3fe0a4173ed"
-dependencies = [
- "async-trait",
- "clap",
- "frame-remote-externalities",
- "frame-try-runtime",
- "hex",
- "log",
- "parity-scale-codec",
- "sc-cli",
- "sc-executor",
- "serde",
- "serde_json",
- "sp-api",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-core",
- "sp-debug-derive",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-rpc",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
- "sp-transaction-storage-proof",
- "sp-version",
- "sp-weights",
- "substrate-rpc-client",
- "zstd 0.12.4",
-]
-
-[[package]]
 name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.21.12",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"
@@ -13574,7 +14489,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -13655,6 +14570,7 @@ dependencies = [
  "bytes",
  "futures-io",
  "futures-util",
+ "tokio-util",
 ]
 
 [[package]]
@@ -13679,6 +14595,12 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -13725,7 +14647,7 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -14135,7 +15057,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -14186,17 +15108,17 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d7d64eabcbf938ac7978ebc0e3385caedacb2967ee6e2a9b9e1b69a2590498"
+checksum = "13acc56783ce7fca15017890034ed043cb91de2caab28a91a5b4209a1214eed4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 33.0.0",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -14207,7 +15129,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -14244,7 +15166,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -14253,7 +15175,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -14262,30 +15184,30 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 31.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "sp-version 34.0.0",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
+ "staging-xcm-executor 12.0.0",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-fee-payment-runtime-api",
@@ -14293,19 +15215,19 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e49413f666c93595698e3e3283fb05d7d5e0a522ecb6d4c6220d959691d479"
+checksum = "0eb9a91bc8d5ec0a260735651284eb4420c1a2de62b2430cf16c723186eabd28"
 dependencies = [
- "frame-support",
+ "frame-support 33.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
 ]
 
 [[package]]
@@ -14393,6 +15315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -14679,19 +15616,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "xcm-fee-payment-runtime-api"
-version = "0.1.0"
+name = "x509-parser"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9c9513e249ed6d355d0243748c70cb0d7ca81d0604707f334fd481d54e8264"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
- "frame-support",
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "xcm-fee-payment-runtime-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92be74937c8012c951c667bb0fb016634ab4adeac46f8106aef331f836059167"
+dependencies = [
+ "frame-support 33.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 12.0.0",
 ]
 
 [[package]]
@@ -14699,6 +15653,18 @@ name = "xcm-procedural"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4717a97970a9cda70d7db53cf50d2615c2f6f6b7c857445325b4a39ea7aa2cd"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "xcm-procedural"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9498be6aff2d380250c4b155faaebe4a83da181a00402dedac6c8166850198"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -14716,7 +15682,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.2",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/r0gue-io/base-parachain"
 
 [workspace]
 members = [
-	"node",
-	"runtime",
+    "node",
+    "runtime",
 ]
 resolver = "2"
 
@@ -30,96 +30,98 @@ smallvec = "1.11.2"
 
 # Build
 substrate-build-script-utils = "11.0.0"
-substrate-wasm-builder = "21.0.0"
+substrate-wasm-builder = "22.0.1"
+docify = "0.2.8"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-frame-benchmarking = { version = "32.0.0", default-features = false }
-frame-benchmarking-cli = "36.0.0"
-frame-executive = { version = "32.0.0", default-features = false }
-frame-support = { version = "32.0.0", default-features = false }
-frame-system = { version = "32.0.0", default-features = false }
-frame-system-benchmarking = { version = "32.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "30.0.0", default-features = false }
-frame-try-runtime = { version = "0.38.0", default-features = false }
-pallet-aura = { version = "31.0.0", default-features = false }
-pallet-authorship = { version = "32.0.0", default-features = false }
-pallet-balances = { version = "33.0.0", default-features = false }
-pallet-message-queue = { version = "35.0.0", default-features = false }
-pallet-session = { version = "32.0.0", default-features = false }
-pallet-sudo = { version = "32.0.0", default-features = false }
-pallet-timestamp = { version = "31.0.0", default-features = false }
-pallet-transaction-payment = { version = "32.0.0", default-features = false }
-pallet-transaction-payment-rpc = "34.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "32.0.0", default-features = false }
-sc-basic-authorship = "0.38.0"
-sc-chain-spec = "31.0.0"
-sc-cli = "0.40.0"
-sc-client-api = "32.0.0"
-sc-offchain = "33.0.0"
-sc-consensus = "0.37.0"
-sc-executor = "0.36.0"
-sc-network = "0.38.0"
-sc-network-sync = "0.37.0"
-sc-rpc = "33.0.0"
-sc-service = "0.39.0"
-sc-sysinfo = "31.0.0"
-sc-telemetry = "18.0.0"
-sc-tracing = "32.0.0"
-sc-transaction-pool = "32.0.0"
-sc-transaction-pool-api = "32.0.0"
-sp-api = { version = "30.0.0", default-features = false }
-sp-block-builder = { version = "30.0.0", default-features = false }
-sp-blockchain = "32.0.0"
-sp-consensus-aura = { version = "0.36.0", default-features = false }
+frame-benchmarking = { version = "33.0.0", default-features = false }
+frame-benchmarking-cli = "37.0.0"
+frame-executive = { version = "33.0.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.2.0", default-features = false }
+frame-support = { version = "33.0.0", default-features = false }
+frame-system = { version = "33.0.0", default-features = false }
+frame-system-benchmarking = { version = "33.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "31.0.0", default-features = false }
+frame-try-runtime = { version = "0.39.0", default-features = false }
+pallet-aura = { version = "32.0.0", default-features = false }
+pallet-authorship = { version = "33.0.0", default-features = false }
+pallet-balances = { version = "34.0.0", default-features = false }
+pallet-message-queue = { version = "36.0.0", default-features = false }
+pallet-session = { version = "33.0.0", default-features = false }
+pallet-sudo = { version = "33.0.0", default-features = false }
+pallet-timestamp = { version = "32.0.0", default-features = false }
+pallet-transaction-payment = { version = "33.0.0", default-features = false }
+pallet-transaction-payment-rpc = "35.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "33.0.0", default-features = false }
+sc-basic-authorship = "0.39.0"
+sc-chain-spec = "32.0.0"
+sc-cli = "0.41.0"
+sc-client-api = "33.0.0"
+sc-offchain = "34.0.0"
+sc-consensus = "0.38.0"
+sc-executor = "0.37.0"
+sc-network = "0.39.0"
+sc-network-sync = "0.38.0"
+sc-rpc = "34.0.0"
+sc-service = "0.40.0"
+sc-sysinfo = "32.0.0"
+sc-telemetry = "19.0.0"
+sc-tracing = "33.0.0"
+sc-transaction-pool = "33.0.0"
+sc-transaction-pool-api = "33.0.0"
+sp-api = { version = "31.0.0", default-features = false }
+sp-block-builder = { version = "31.0.0", default-features = false }
+sp-blockchain = "33.0.0"
+sp-consensus-aura = { version = "0.37.0", default-features = false }
 sp-core = { version = "32.0.0", default-features = false }
-sp-io = { version = "34.0.0", default-features = false }
-sp-genesis-builder = { version = "0.11.0", default-features = false }
-sp-inherents = { version = "30.0.0", default-features = false }
+sp-io = { version = "35.0.0", default-features = false }
+sp-genesis-builder = { version = "0.12.0", default-features = false }
+sp-inherents = { version = "31.0.0", default-features = false }
 sp-keystore = "0.38.0"
-sp-offchain = { version = "30.0.0", default-features = false }
-sp-runtime = { version = "35.0.0", default-features = false }
-sp-session = { version = "31.0.0", default-features = false }
+sp-offchain = { version = "31.0.0", default-features = false }
+sp-runtime = { version = "36.0.0", default-features = false }
+sp-session = { version = "32.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = "30.0.0"
-sp-transaction-pool = { version = "30.0.0", default-features = false }
-sp-version = { version = "33.0.0", default-features = false }
-substrate-frame-rpc-system = "32.0.0"
+sp-timestamp = "31.0.0"
+sp-transaction-pool = { version = "31.0.0", default-features = false }
+sp-version = { version = "34.0.0", default-features = false }
+substrate-frame-rpc-system = "33.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
 pallet-contracts = { version = "31.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "11.0.0", default-features = false }
-polkadot-cli = "11.0.0"
-polkadot-parachain-primitives = { version = "10.0.0", default-features = false }
-polkadot-primitives = "11.0.0"
-polkadot-runtime-common = { version = "11.0.0", default-features = false }
-xcm = { version = "11.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "11.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "11.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "12.0.0", default-features = false }
+polkadot-cli = "12.0.0"
+polkadot-parachain-primitives = { version = "11.0.0", default-features = false }
+polkadot-primitives = "12.0.0"
+polkadot-runtime-common = { version = "12.0.0", default-features = false }
+xcm = { version = "12.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "12.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "12.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.11.0"
-cumulus-client-collator = "0.11.0"
-cumulus-client-consensus-aura = "0.11.0"
-cumulus-client-consensus-common = "0.11.0"
-cumulus-client-consensus-proposer = "0.11.0"
-cumulus-client-service = "0.11.0"
-cumulus-pallet-aura-ext = { version = "0.11.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.11.0", default-features = false, features = ["parameterized-consensus-hook"] }
-cumulus-pallet-session-benchmarking = { version = "13.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.11.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.11.0", default-features = false }
-cumulus-primitives-aura = { version = "0.11.0", default-features = false }
-cumulus-primitives-core = { version = "0.11.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.11.0"
-cumulus-primitives-storage-weight-reclaim = { version = "2.0.0", default-features = false }
-cumulus-primitives-utility = { version = "0.11.0", default-features = false }
-cumulus-relay-chain-interface = "0.11.0"
-pallet-collator-selection = { version = "13.0.1", default-features = false }
-parachains-common = { version = "11.0.0", default-features = false }
-parachain-info = { version = "0.11.0", package = "staging-parachain-info", default-features = false }
+cumulus-client-cli = "0.12.0"
+cumulus-client-collator = "0.12.0"
+cumulus-client-consensus-aura = "0.12.0"
+cumulus-client-consensus-common = "0.12.0"
+cumulus-client-consensus-proposer = "0.12.0"
+cumulus-client-service = "0.12.0"
+cumulus-pallet-aura-ext = { version = "0.12.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.12.0", default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { version = "14.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.12.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.12.0", default-features = false }
+cumulus-primitives-aura = { version = "0.12.0", default-features = false }
+cumulus-primitives-core = { version = "0.12.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.12.0"
+cumulus-primitives-storage-weight-reclaim = { version = "3.0.0", default-features = false }
+cumulus-primitives-utility = { version = "0.12.0", default-features = false }
+cumulus-relay-chain-interface = "0.12.0"
+pallet-collator-selection = { version = "14.0.0", default-features = false }
+parachains-common = { version = "12.0.0", default-features = false }
+parachain-info = { version = "0.12.0", package = "staging-parachain-info", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ substrate-frame-rpc-system = "33.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
-pallet-contracts = { version = "31.0.0", default-features = false }
+pallet-contracts = { version = "32.0.0", default-features = false }
 
 # Polkadot
 pallet-xcm = { version = "12.0.0", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -60,7 +60,7 @@ substrate-frame-rpc-system.workspace = true
 substrate-prometheus-endpoint.workspace = true
 
 # Polkadot
-polkadot-cli.workspace = true
+polkadot-cli = { workspace = true, features = ["rococo-native"] }
 polkadot-primitives.workspace = true
 xcm.workspace = true
 
@@ -78,17 +78,17 @@ cumulus-relay-chain-interface.workspace = true
 [features]
 default = []
 runtime-benchmarks = [
-	"cumulus-primitives-core/runtime-benchmarks",
-	"frame-benchmarking-cli/runtime-benchmarks",
-	"frame-benchmarking/runtime-benchmarks",
-	"parachain-template-runtime/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
-	"polkadot-primitives/runtime-benchmarks",
-	"sc-service/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
+    "cumulus-primitives-core/runtime-benchmarks",
+    "frame-benchmarking-cli/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "parachain-template-runtime/runtime-benchmarks",
+    "polkadot-cli/runtime-benchmarks",
+    "polkadot-primitives/runtime-benchmarks",
+    "sc-service/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"parachain-template-runtime/try-runtime",
-	"polkadot-cli/try-runtime",
-	"sp-runtime/try-runtime",
+    "parachain-template-runtime/try-runtime",
+    "polkadot-cli/try-runtime",
+    "sp-runtime/try-runtime",
 ]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -38,11 +38,6 @@ pub enum Subcommand {
     /// The pallet benchmarking moved to the `pallet` sub-command.
     #[command(subcommand)]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
-
-    /// Try-runtime has migrated to a standalone
-    /// [CLI](<https://github.com/paritytech/try-runtime-cli>). The subcommand exists as a stub and
-    /// deprecation notice. It will be removed entirely some time after January 2024.
-    TryRuntime,
 }
 
 const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -10,7 +10,6 @@ use sc_cli::{
     NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
-use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
     chain_spec,
@@ -117,157 +116,162 @@ pub fn run() -> Result<()> {
     let cli = Cli::from_args();
 
     match &cli.subcommand {
-		Some(Subcommand::BuildSpec(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-		},
-		Some(Subcommand::CheckBlock(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.import_queue))
-			})
-		},
-		Some(Subcommand::ExportBlocks(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, config.database))
-			})
-		},
-		Some(Subcommand::ExportState(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, config.chain_spec))
-			})
-		},
-		Some(Subcommand::ImportBlocks(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.import_queue))
-			})
-		},
-		Some(Subcommand::Revert(cmd)) => {
-			construct_async_run!(|components, cli, cmd, config| {
-				Ok(cmd.run(components.client, components.backend, None))
-			})
-		},
-		Some(Subcommand::PurgeChain(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
+        Some(Subcommand::BuildSpec(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+        }
+        Some(Subcommand::CheckBlock(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.import_queue))
+            })
+        }
+        Some(Subcommand::ExportBlocks(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, config.database))
+            })
+        }
+        Some(Subcommand::ExportState(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, config.chain_spec))
+            })
+        }
+        Some(Subcommand::ImportBlocks(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.import_queue))
+            })
+        }
+        Some(Subcommand::Revert(cmd)) => {
+            construct_async_run!(|components, cli, cmd, config| {
+                Ok(cmd.run(components.client, components.backend, None))
+            })
+        }
+        Some(Subcommand::PurgeChain(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
 
-			runner.sync_run(|config| {
-				let polkadot_cli = RelayChainCli::new(
-					&config,
-					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
-				);
+            runner.sync_run(|config| {
+                let polkadot_cli = RelayChainCli::new(
+                    &config,
+                    [RelayChainCli::executable_name()]
+                        .iter()
+                        .chain(cli.relay_chain_args.iter()),
+                );
 
-				let polkadot_config = SubstrateCli::create_configuration(
-					&polkadot_cli,
-					&polkadot_cli,
-					config.tokio_handle.clone(),
-				)
-				.map_err(|err| format!("Relay chain argument error: {}", err))?;
+                let polkadot_config = SubstrateCli::create_configuration(
+                    &polkadot_cli,
+                    &polkadot_cli,
+                    config.tokio_handle.clone(),
+                )
+                .map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				cmd.run(config, polkadot_config)
-			})
-		},
-		Some(Subcommand::ExportGenesisHead(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| {
-				let partials = new_partial(&config)?;
+                cmd.run(config, polkadot_config)
+            })
+        }
+        Some(Subcommand::ExportGenesisHead(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|config| {
+                let partials = new_partial(&config)?;
 
-				cmd.run(partials.client)
-			})
-		},
-		Some(Subcommand::ExportGenesisWasm(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|_config| {
-				let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
-				cmd.run(&*spec)
-			})
-		},
-		Some(Subcommand::Benchmark(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			// Switch on the concrete benchmark sub-command-
-			match cmd {
-				BenchmarkCmd::Pallet(cmd) =>
-					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ReclaimHostFunctions>(config))
-					} else {
-						Err("Benchmarking wasn't enabled when building the node. \
+                cmd.run(partials.client)
+            })
+        }
+        Some(Subcommand::ExportGenesisWasm(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            runner.sync_run(|_config| {
+                let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
+                cmd.run(&*spec)
+            })
+        }
+        Some(Subcommand::Benchmark(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+            // Switch on the concrete benchmark sub-command-
+            match cmd {
+                BenchmarkCmd::Pallet(cmd) => {
+                    if cfg!(feature = "runtime-benchmarks") {
+                        runner.sync_run(|config| cmd.run_with_spec::<sp_runtime::traits::HashingFor<Block>, ReclaimHostFunctions>(Some(config.chain_spec)))
+                    } else {
+                        Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."
-							.into())
-					},
-				BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
-					let partials = new_partial(&config)?;
-					cmd.run(partials.client)
-				}),
-				#[cfg(not(feature = "runtime-benchmarks"))]
-				BenchmarkCmd::Storage(_) =>
-					Err(sc_cli::Error::Input(
-						"Compile with --features=runtime-benchmarks \
+                            .into())
+                    }
+                }
+                BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
+                    let partials = new_partial(&config)?;
+                    cmd.run(partials.client)
+                }),
+                #[cfg(not(feature = "runtime-benchmarks"))]
+                BenchmarkCmd::Storage(_) => Err(sc_cli::Error::Input(
+                    "Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
-							.into(),
-					)),
-				#[cfg(feature = "runtime-benchmarks")]
-				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
-					let partials = new_partial(&config)?;
-					let db = partials.backend.expose_db();
-					let storage = partials.backend.expose_storage();
-					cmd.run(config, partials.client.clone(), db, storage)
-				}),
-				BenchmarkCmd::Machine(cmd) =>
-					runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone())),
-				// NOTE: this allows the Client to leniently implement
-				// new benchmark commands without requiring a companion MR.
-				#[allow(unreachable_patterns)]
-				_ => Err("Benchmarking sub-command unsupported".into()),
-			}
-		},
-		Some(Subcommand::TryRuntime) => Err("The `try-runtime` subcommand has been migrated to a standalone CLI (https://github.com/paritytech/try-runtime-cli). It is no longer being maintained here and will be removed entirely some time after January 2024. Please remove this subcommand from your runtime and use the standalone CLI.".into()),
-		None => {
-			let runner = cli.create_runner(&cli.run.normalize())?;
-			let collator_options = cli.run.collator_options();
+                        .into(),
+                )),
+                #[cfg(feature = "runtime-benchmarks")]
+                BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
+                    let partials = new_partial(&config)?;
+                    let db = partials.backend.expose_db();
+                    let storage = partials.backend.expose_storage();
+                    cmd.run(config, partials.client.clone(), db, storage)
+                }),
+                BenchmarkCmd::Machine(cmd) => {
+                    runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()))
+                }
+                // NOTE: this allows the Client to leniently implement
+                // new benchmark commands without requiring a companion MR.
+                #[allow(unreachable_patterns)]
+                _ => Err("Benchmarking sub-command unsupported".into()),
+            }
+        }
+        None => {
+            let runner = cli.create_runner(&cli.run.normalize())?;
+            let collator_options = cli.run.collator_options();
 
-			runner.run_node_until_exit(|config| async move {
-				let hwbench = (!cli.no_hardware_benchmarks)
-					.then_some(config.database.path().map(|database_path| {
-						let _ = std::fs::create_dir_all(database_path);
-						sc_sysinfo::gather_hwbench(Some(database_path))
-					}))
-					.flatten();
+            runner.run_node_until_exit(|config| async move {
+                let hwbench = (!cli.no_hardware_benchmarks)
+                    .then_some(config.database.path().map(|database_path| {
+                        let _ = std::fs::create_dir_all(database_path);
+                        sc_sysinfo::gather_hwbench(Some(database_path))
+                    }))
+                    .flatten();
 
-				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
-					.map(|e| e.para_id)
-					.ok_or("Could not find parachain ID in chain-spec.")?;
+                let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
+                    .map(|e| e.para_id)
+                    .ok_or("Could not find parachain ID in chain-spec.")?;
 
-				let polkadot_cli = RelayChainCli::new(
-					&config,
-					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
-				);
+                let polkadot_cli = RelayChainCli::new(
+                    &config,
+                    [RelayChainCli::executable_name()]
+                        .iter()
+                        .chain(cli.relay_chain_args.iter()),
+                );
 
-				let id = ParaId::from(para_id);
+                let id = ParaId::from(para_id);
 
-				let parachain_account =
-					AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(
-						&id,
-					);
+                let tokio_handle = config.tokio_handle.clone();
+                let polkadot_config =
+                    SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
+                        .map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				let tokio_handle = config.tokio_handle.clone();
-				let polkadot_config =
-					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
-						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+                info!(
+                    "Is collating: {}",
+                    if config.role.is_authority() {
+                        "yes"
+                    } else {
+                        "no"
+                    }
+                );
 
-				info!("Parachain Account: {parachain_account}");
-				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
-
-				crate::service::start_parachain_node(
-					config,
-					polkadot_config,
-					collator_options,
-					id,
-					hwbench,
-				)
-				.await
-				.map(|r| r.0)
-				.map_err(Into::into)
-			})
-		},
-	}
+                crate::service::start_parachain_node(
+                    config,
+                    polkadot_config,
+                    collator_options,
+                    id,
+                    hwbench,
+                )
+                .await
+                .map(|r| r.0)
+                .map_err(Into::into)
+            })
+        }
+    }
 }
 
 impl DefaultConfigurationValues for RelayChainCli {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -125,7 +125,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
         config,
         telemetry.as_ref().map(|telemetry| telemetry.handle()),
         &task_manager,
-    )?;
+    );
 
     Ok(PartialComponents {
         backend,
@@ -139,11 +139,106 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
     })
 }
 
+/// Build the import queue for the parachain runtime.
+fn build_import_queue(
+    client: Arc<ParachainClient>,
+    block_import: ParachainBlockImport,
+    config: &Configuration,
+    telemetry: Option<TelemetryHandle>,
+    task_manager: &TaskManager,
+) -> sc_consensus::DefaultImportQueue<Block> {
+    cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
+        sp_consensus_aura::sr25519::AuthorityPair,
+        _,
+        _,
+        _,
+        _,
+    >(
+        client,
+        block_import,
+        move |_, _| async move {
+            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+            Ok(timestamp)
+        },
+        &task_manager.spawn_essential_handle(),
+        config.prometheus_registry(),
+        telemetry,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_consensus(
+    client: Arc<ParachainClient>,
+    backend: Arc<ParachainBackend>,
+    block_import: ParachainBlockImport,
+    prometheus_registry: Option<&Registry>,
+    telemetry: Option<TelemetryHandle>,
+    task_manager: &TaskManager,
+    relay_chain_interface: Arc<dyn RelayChainInterface>,
+    transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
+    sync_oracle: Arc<SyncingService<Block>>,
+    keystore: KeystorePtr,
+    relay_chain_slot_duration: Duration,
+    para_id: ParaId,
+    collator_key: CollatorPair,
+    overseer_handle: OverseerHandle,
+    announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+) -> Result<(), sc_service::Error> {
+    let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
+        task_manager.spawn_handle(),
+        client.clone(),
+        transaction_pool,
+        prometheus_registry,
+        telemetry.clone(),
+    );
+
+    let proposer = Proposer::new(proposer_factory);
+
+    let collator_service = CollatorService::new(
+        client.clone(),
+        Arc::new(task_manager.spawn_handle()),
+        announce_block,
+        client.clone(),
+    );
+
+    let params = AuraParams {
+        create_inherent_data_providers: move |_, ()| async move { Ok(()) },
+        block_import,
+        para_client: client.clone(),
+        para_backend: backend,
+        relay_client: relay_chain_interface,
+        code_hash_provider: move |block_hash| {
+            client
+                .code_at(block_hash)
+                .ok()
+                .map(|c| ValidationCode::from(c).hash())
+        },
+        sync_oracle,
+        keystore,
+        collator_key,
+        para_id,
+        overseer_handle,
+        relay_chain_slot_duration,
+        proposer,
+        collator_service,
+        authoring_duration: Duration::from_millis(2000),
+        reinitialize: false,
+    };
+
+    let fut =
+        aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(
+            params,
+        );
+    task_manager
+        .spawn_essential_handle()
+        .spawn("aura", None, fut);
+
+    Ok(())
+}
+
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
-///
-/// This is the actual implementation that is abstract over the executor and the runtime api.
 #[sc_tracing::logging::prefix_logs_with("Parachain")]
-async fn start_node_impl(
+pub async fn start_parachain_node(
     parachain_config: Configuration,
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
@@ -154,7 +249,11 @@ async fn start_node_impl(
 
     let params = new_partial(&parachain_config)?;
     let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
-    let net_config = sc_network::config::FullNetworkConfiguration::new(&parachain_config.network);
+    let net_config = sc_network::config::FullNetworkConfiguration::<
+        _,
+        _,
+        sc_network::NetworkWorker<Block, Hash>,
+    >::new(&parachain_config.network);
 
     let client = params.client.clone();
     let backend = params.backend.clone();
@@ -176,6 +275,8 @@ async fn start_node_impl(
     let transaction_pool = params.transaction_pool.clone();
     let import_queue_service = params.import_queue.service();
 
+    // NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
+    // when starting the network.
     let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
         build_network(BuildNetworkParams {
             parachain_config: &parachain_config,
@@ -203,7 +304,7 @@ async fn start_node_impl(
                 transaction_pool: Some(OffchainTransactionPoolFactory::new(
                     transaction_pool.clone(),
                 )),
-                network_provider: network.clone(),
+                network_provider: Arc::new(network.clone()),
                 is_validator: parachain_config.role.is_authority(),
                 enable_http_requests: false,
                 custom_extensions: move |_| vec![],
@@ -319,124 +420,4 @@ async fn start_node_impl(
     start_network.start_network();
 
     Ok((task_manager, client))
-}
-
-/// Build the import queue for the parachain runtime.
-fn build_import_queue(
-    client: Arc<ParachainClient>,
-    block_import: ParachainBlockImport,
-    config: &Configuration,
-    telemetry: Option<TelemetryHandle>,
-    task_manager: &TaskManager,
-) -> Result<sc_consensus::DefaultImportQueue<Block>, sc_service::Error> {
-    let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
-
-    Ok(
-        cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
-            sp_consensus_aura::sr25519::AuthorityPair,
-            _,
-            _,
-            _,
-            _,
-        >(
-            client,
-            block_import,
-            move |_, _| async move {
-                let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-                Ok(timestamp)
-            },
-            slot_duration,
-            &task_manager.spawn_essential_handle(),
-            config.prometheus_registry(),
-            telemetry,
-        ),
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn start_consensus(
-    client: Arc<ParachainClient>,
-    backend: Arc<ParachainBackend>,
-    block_import: ParachainBlockImport,
-    prometheus_registry: Option<&Registry>,
-    telemetry: Option<TelemetryHandle>,
-    task_manager: &TaskManager,
-    relay_chain_interface: Arc<dyn RelayChainInterface>,
-    transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
-    sync_oracle: Arc<SyncingService<Block>>,
-    keystore: KeystorePtr,
-    relay_chain_slot_duration: Duration,
-    para_id: ParaId,
-    collator_key: CollatorPair,
-    overseer_handle: OverseerHandle,
-    announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
-) -> Result<(), sc_service::Error> {
-    let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
-        task_manager.spawn_handle(),
-        client.clone(),
-        transaction_pool,
-        prometheus_registry,
-        telemetry.clone(),
-    );
-
-    let proposer = Proposer::new(proposer_factory);
-
-    let collator_service = CollatorService::new(
-        client.clone(),
-        Arc::new(task_manager.spawn_handle()),
-        announce_block,
-        client.clone(),
-    );
-
-    let params = AuraParams {
-        create_inherent_data_providers: move |_, ()| async move { Ok(()) },
-        block_import,
-        para_client: client.clone(),
-        para_backend: backend,
-        relay_client: relay_chain_interface,
-        code_hash_provider: move |block_hash| {
-            client
-                .code_at(block_hash)
-                .ok()
-                .map(|c| ValidationCode::from(c).hash())
-        },
-        sync_oracle,
-        keystore,
-        collator_key,
-        para_id,
-        overseer_handle,
-        relay_chain_slot_duration,
-        proposer,
-        collator_service,
-        authoring_duration: Duration::from_millis(2000),
-        reinitialize: false,
-    };
-
-    let fut =
-        aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(
-            params,
-        );
-    task_manager
-        .spawn_essential_handle()
-        .spawn("aura", None, fut);
-
-    Ok(())
-}
-
-/// Start a parachain node.
-pub async fn start_parachain_node(
-    parachain_config: Configuration,
-    polkadot_config: Configuration,
-    collator_options: CollatorOptions,
-    para_id: ParaId,
-    hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
-    start_node_impl(
-        parachain_config,
-        polkadot_config,
-        collator_options,
-        para_id,
-        hwbench,
-    )
-    .await
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 substrate-wasm-builder.workspace = true
+docify.workspace = true
 
 [dependencies]
 codec.workspace = true
@@ -25,6 +26,7 @@ smallvec.workspace = true
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive.workspace = true
+frame-metadata-hash-extension.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -90,6 +92,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking/std",
 	"frame-system-rpc-runtime-api/std",
@@ -179,3 +182,16 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+# Enable the metadata hash generation.
+#
+# This is hidden behind a feature because it increases the compile time.
+# The wasm binary needs to be compiled twice, once to fetch the metadata,
+# generate the metadata hash and then a second time with the
+# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
+# extension.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
+# A convenience feature for enabling things when doing a build
+# for an on-chain release.
+on-chain-release-build = ["metadata-hash"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,10 +1,14 @@
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[docify::export(template_enable_metadata_hash)]
 fn main() {
-    substrate_wasm_builder::WasmBuilder::new()
-        .with_current_project()
-        .export_heap_base()
-        .import_memory()
-        .build()
+    substrate_wasm_builder::WasmBuilder::init_with_defaults()
+        .enable_metadata_hash("UNIT", 12)
+        .build();
+}
+
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
+fn main() {
+    substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 /// The wasm builder is deactivated when compiling

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -25,7 +25,7 @@
 
 // External crates imports
 use frame_support::{
-    genesis_builder_helper::{build_config, create_default_config},
+    genesis_builder_helper::{build_state, get_preset},
     weights::Weight,
 };
 use pallet_aura::Authorities;
@@ -346,12 +346,16 @@ impl_runtime_apis! {
     }
 
     impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
-        fn create_default_config() -> Vec<u8> {
-            create_default_config::<RuntimeGenesisConfig>()
+        fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
+            build_state::<RuntimeGenesisConfig>(config)
         }
 
-        fn build_config(config: Vec<u8>) -> sp_genesis_builder::Result {
-            build_config::<RuntimeGenesisConfig>(config)
+        fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+            get_preset::<RuntimeGenesisConfig>(id, |_| None)
+        }
+
+        fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+            Default::default()
         }
     }
 }

--- a/runtime/src/benchmarks.rs
+++ b/runtime/src/benchmarks.rs
@@ -1,0 +1,37 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org>
+
+frame_benchmarking::define_benchmarks!(
+    // Only benchmark the following pallets
+    [frame_system, SystemBench::<Runtime>]
+    [cumulus_pallet_parachain_system, ParachainSystem]
+    [pallet_timestamp, Timestamp]
+    [pallet_balances, Balances]
+    [pallet_sudo, Sudo]
+    [pallet_collator_selection, CollatorSelection]
+    [pallet_session, SessionBench::<Runtime>]
+    [cumulus_pallet_xcmp_queue, XcmpQueue]
+    [pallet_message_queue, MessageQueue]
+);

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -167,7 +167,7 @@ parameter_types! {
 
 impl pallet_transaction_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction = pallet_transaction_payment::FungibleAdapter<Balances, ()>;
     type WeightToFee = WeightToFee;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
     type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;

--- a/runtime/src/configs/xcm.rs
+++ b/runtime/src/configs/xcm.rs
@@ -58,6 +58,8 @@ parameter_types! {
     pub const RelayNetwork: Option<NetworkId> = None;
     pub const TokenLocation: Location = Location::here();
     pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
+    // For the real deployment, it is recommended to set `RelayNetwork` according to the relay chain
+    // and prepend `UniversalLocation` with `GlobalConsensus(RelayNetwork::get())`.
     pub UniversalLocation: InteriorLocation = Parachain(ParachainInfo::parachain_id().into()).into();
     pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -32,6 +32,8 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 pub mod apis;
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarks;
 mod configs;
 mod weights;
 
@@ -107,6 +109,7 @@ pub type SignedExtra = (
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+    frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -300,22 +303,6 @@ construct_runtime!(
         Contracts: pallet_contracts = 40,
     }
 );
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benches {
-    frame_benchmarking::define_benchmarks!(
-        // Only benchmark the following pallets
-        [frame_system, SystemBench::<Runtime>]
-        [cumulus_pallet_parachain_system, ParachainSystem]
-        [pallet_timestamp, Timestamp]
-        [pallet_balances, Balances]
-        [pallet_sudo, Sudo]
-        [pallet_collator_selection, CollatorSelection]
-        [pallet_session, SessionBench::<Runtime>]
-        [cumulus_pallet_xcmp_queue, XcmpQueue]
-        [pallet_message_queue, MessageQueue]
-    );
-}
 
 cumulus_pallet_parachain_system::register_validate_block! {
     Runtime = Runtime,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75" # pinned to version used with polkadot release
+channel = "1.77" # pinned to version used with polkadot release
 components = ["rust-src", "rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Followed the same process as described in `assets-parachain`:  https://github.com/r0gue-io/assets-parachain/pull/5