### PR TITLE
chore: upgrade to polkadot v1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -902,8 +891,8 @@ checksum = "b493c8238552fb50edfe9c3eb94e8058fce36cce71cc9ad0fb1902d3aedcd902"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1633,8 +1622,8 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "url",
 ]
 
@@ -1655,10 +1644,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1689,17 +1678,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1727,10 +1716,10 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-timestamp",
- "sp-trie 35.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1745,9 +1734,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -1764,14 +1753,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "tracing",
 ]
 
@@ -1789,14 +1778,14 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-crypto-hashing",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-storage",
- "sp-trie 35.0.0",
+ "sp-trie",
  "tracing",
 ]
 
@@ -1821,7 +1810,7 @@ dependencies = [
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -1854,12 +1843,12 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
@@ -1870,15 +1859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98aaa88ee4435475935579907b03e4f60b086c6878945868a4d4e31510957431"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1894,28 +1883,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 35.0.0",
- "sp-version 35.0.0",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
+ "sp-trie",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
  "trie-db",
 ]
 
@@ -1937,12 +1926,12 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4f32808caa41da9a1db60e1de9e7ba84eb7370067f481ecc7ceb137aede0ac5"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1953,14 +1942,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bfe7a26ebf90b71ab9cb75f983f29d9a2a47205fabde8ad6d8589c629f1851"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 13.0.1",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -1972,22 +1961,22 @@ dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -1997,11 +1986,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35269d04c8b6a775be07c49e5512f383d455bb91fe951adef8c72d45600a9acd"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 13.0.0",
+ "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus-aura",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2012,15 +2001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8947e8b09cef060025d11a8da171f698da4d9b67191b5bc3f96d6cec553f17d"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 13.0.0",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
- "sp-trie 35.0.0",
- "staging-xcm 13.0.1",
+ "sp-trie",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2033,12 +2022,12 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 35.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2049,7 +2038,7 @@ checksum = "f815c73e6d8a5b44daac8881770137a99364d4c531ae9a21b2e6909a889631f1"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie 35.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2061,12 +2050,12 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2077,18 +2066,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3195604b37c3de5407201cf77deabb4436a6ddb2db6206bc72aa6a356402532e"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 34.0.0",
+ "frame-support",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -2109,11 +2098,11 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -2129,9 +2118,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-state-machine 0.41.0",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -2150,7 +2139,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 13.0.0",
+ "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2168,11 +2157,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2203,14 +2192,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-version 35.0.0",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2227,10 +2216,10 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 35.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2675,20 +2664,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown 0.12.3",
- "hex",
- "rand_core 0.6.4",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
@@ -3106,50 +3081,24 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
-dependencies = [
- "frame-support 33.0.0",
- "frame-support-procedural 28.0.0",
- "frame-system 33.0.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 31.0.0",
- "sp-application-crypto 35.0.0",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130b79108bca3d8850e850c276f1012058593d6a2a8774132e72766245bbcacc"
 dependencies = [
- "frame-support 34.0.0",
- "frame-support-procedural 29.0.1",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-support-procedural",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3167,9 +3116,9 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "gethostname",
  "handlebars",
  "itertools 0.11.0",
@@ -3189,19 +3138,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder 0.13.0",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-trie 35.0.0",
+ "sp-trie",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3226,14 +3175,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e498d8b21ba927024302645e0f4d0d0136c9620808d8425bb309fb8a92d3ff"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-npos-elections",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3244,15 +3193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5ab937cea917f5875b0e08d55ed941f9c82c2b08628d6bf47b90c63c48ef607"
 dependencies = [
  "aquamarine",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
 ]
@@ -3271,48 +3220,6 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d04fc1fdbc7bdcb1cb54834e16a5194e5a16a25bfdaca1b761ee9ff4963366f"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata",
- "frame-support-procedural 28.0.0",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 31.0.0",
- "sp-arithmetic",
- "sp-core 32.0.0",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.12.0",
- "sp-inherents 31.0.0",
- "sp-io 35.0.0",
- "sp-metadata-ir",
- "sp-runtime 36.0.0",
- "sp-staking 31.0.0",
- "sp-state-machine 0.40.0",
- "sp-std",
- "sp-tracing",
- "sp-weights",
- "static_assertions",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c177377726d7bb598dd942e38168c1eb6872d53810a6bf810f0a428f9a46be8"
@@ -3323,7 +3230,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural 29.0.1",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3334,43 +3241,23 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-arithmetic",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.13.0",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
- "sp-state-machine 0.41.0",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
  "sp-weights",
  "static_assertions",
  "tt-call",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8eaf3bb331b98427158733e221bd6fb79e9f213da55b305e159dc023d41fd2"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse 0.2.0",
- "expander",
- "frame-support-procedural-tools",
- "itertools 0.10.5",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -3419,43 +3306,22 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 33.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
- "sp-version 34.0.0",
- "sp-weights",
-]
-
-[[package]]
-name = "frame-system"
 version = "34.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85777d5cb78d8f244aa4e92a06d13c234f7980dd7095b1baeefc23a5945cad6c"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 34.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "sp-version 35.0.0",
+ "sp-version",
  "sp-weights",
 ]
 
@@ -3465,13 +3331,13 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2df1ebcb669ae29aec03f6f87b232f2446942fb79fad72434d8d0a0fd7df917"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3482,7 +3348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd92e3fe18b93d456efdabbd98070a1d720be5b6affe589379db9b7d9272eba5"
 dependencies = [
  "parity-scale-codec",
- "sp-api 32.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -3491,10 +3357,10 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "748a6c8286447388ff7a35d88fc2e0be3b26238c609c88b7774615c274452413"
 dependencies = [
- "frame-support 34.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -3866,9 +3732,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3876,7 +3739,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
 ]
 
 [[package]]
@@ -3885,7 +3748,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
@@ -5689,13 +5552,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 37.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5707,11 +5570,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 37.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6351,17 +6214,17 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7428d88b215ade92402d6c01ad02f51b6bba02c69fab8c174e0b223b335d773"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6371,13 +6234,13 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ebd9fbc2bdd0015bc015103a596035de2b41d01f339f7fe732885fbd774ba0"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6387,16 +6250,16 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428dad50f10165a0d9757443733e38c94f371578fe44c9c989457d2cd61080ed"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
- "pallet-transaction-payment 34.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6406,14 +6269,14 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce4a9e4704ec26889ed2245064d389251a04314c144239c08c9340ea5e14d1e"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6423,15 +6286,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cfc84d2d716e23948f9777f97cf1c57461d33b22dcceeeb03493b3ad1059b"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6441,14 +6304,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9b476d5331907127d707a184f5454c8ded644c1530115241a576c578ecdfea"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6458,12 +6321,12 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd3d28c92dff65f0d198e88e3689f5282903138102bff84cc3794a1426665fc"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6473,22 +6336,22 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43127ee85b3a00650557a269efe1409f192df52e01abbed18dbaee9b5ccc174d"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6500,36 +6363,19 @@ checksum = "597db43f545daa97771c2c84f8d53e7b6596a37f58fe28329b221cfc45cb7575"
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-tracing",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
-dependencies = [
- "docify",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 36.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -6539,13 +6385,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bd03d979e84ec22862e62bece760601c10cc72712aa1fc43358ae9837dc9fd"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6555,8 +6401,8 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a8f4f497878782988bdd7df0a825b4757921804fb7bafcc8df3b9e990c7a0"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6564,9 +6410,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6578,8 +6424,8 @@ checksum = "c3e144caa40bc9a8b2947a0de2cb5eae3e701790bf9c2105536b6943d234aa7e"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6587,12 +6433,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus-beefy",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
 ]
 
@@ -6602,16 +6448,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f1b72d43025037e2ef80598ddd2a7d2d7af7e592173fa49d787b405a314c24"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6622,16 +6468,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dbfcca449d6ab4c922c4ea78647f0f9d0df0ddc29e23e2bf6c51bfd86abd97f"
 dependencies = [
  "bitvec",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6641,17 +6487,17 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05475c4590ac456090c430d5f8b0a3b66820048bd3b25fb273a992ea8c8e36e"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6661,18 +6507,18 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "191fe5efd59d6e68d36b15e5abf86a7169a3c1754e2a55f0ecd0555e8326eb05"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6682,32 +6528,32 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5669703e0437057c1054e73c10f8f2e256850905e318b0c235a587cbd89d616"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8117764e8436e9ad3f134c313a65b0dad95f1353349ddd9a78a6b527dbbeb320"
+checksum = "5ca700e816a32739ab9480065a2546181f83e743c93f74b244463dd87b48e5aa"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "frame-system 33.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 34.0.0",
+ "pallet-balances",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
@@ -6717,13 +6563,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 31.0.0",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 12.0.0",
- "staging-xcm-builder 12.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
  "wasm-instrument",
  "wasmi",
 ]
@@ -6759,14 +6605,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19d08a0f7f23bb70998456f04f0234548f6ee10507b0f7e74bf067e3eeeee2b"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6776,16 +6622,16 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731fc36423b38b08b12dd3a3aeeaa1dda61a3207ee5ce24a209d964aede8a367"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6795,20 +6641,20 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbfdd85dd5d5979067a47d4148f529da937ee017a846e98d4778764b3acfe43"
 dependencies = [
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
  "strum 0.26.2",
 ]
@@ -6819,12 +6665,12 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef65188f4db678f5b5098d74f67e35ea5a1c2eac3c57e628e8371bf013e5f7ff"
 dependencies = [
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-system 34.0.1",
+ "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6834,17 +6680,17 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2306b2b9115109232e590604edc35395b33fbf7413a84bfdb24ae0e0b9e3585d"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6855,16 +6701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202d0ffa99727097251e049039fc40a4bfba7f32d0f1c831614cc94f95d430bc"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6874,21 +6720,21 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176f4dacb8f2e4f7cc807df18ced790d928c736b761b0eac5a855e9052efde40"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6899,14 +6745,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435fb7144dd4809744d6ed5bdb96da650f59456ee95eac886e8b63ce2288f041"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6916,18 +6762,18 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb18daba67af89afab884392286b22c9da983d63adc2b4f42be42330fb645da8"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -6937,15 +6783,15 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5474e1fe28673aa229805fa59bda1b5211a6cd5acd44d1ce8594761c5aa6a3"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6955,15 +6801,15 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958dd8feceeeacd1ae268eb0c2133887aea5f9883ae3410712f7b483b265c145"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6974,16 +6820,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f00efb1a89581346901a13f60c6d5be640dbfee516342f0b6b1ee679ed20354"
 dependencies = [
  "environmental",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -6994,16 +6840,16 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359e1e6b63a3fdd57724c35b428c5cb13d2203108f643beb5870e72d0173af5c"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-mmr-primitives",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7013,14 +6859,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98b5d37656066f03706dd9edf472785b531bb9dedec7d2a9c147cce2d4f30061"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7030,14 +6876,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e4b82d3d48d0b0828acac780b2a383f1bb4fe2b33d945850d735571f8f0398"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7047,16 +6893,16 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e13bbfb772e3530e4adb0ed000d5851c89c1e21949f199196d5aed4573d6c1"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
  "sp-tracing",
 ]
@@ -7067,18 +6913,18 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef69c75bf20f34c61d8fa9e2eaac7e0196662c1f837193b980dd81ce8bf64b7f"
 dependencies = [
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7090,7 +6936,7 @@ checksum = "436388be290be799b0eaebb3bf0faa71029d8326fa5726c578302cb1e8f78032"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -7100,15 +6946,15 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd8a7f971f79e0ced152437e2e2c3aa3d3230c347cb7042dac81bbf58518751e"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7118,13 +6964,13 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87737faadaca16055217d7d4cace15fa47690a74e077ca3ca2269ac9d63928f5"
 dependencies = [
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-babe",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -7132,8 +6978,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7144,15 +6990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61797dcd19a4bc6367b031df02209182d410c00ce08a7d1d2d4ec00be54af4c"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7162,15 +7008,15 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c464ba4684a0349c0266a50bb43b281cbed79ef2a217872796c433d293fa15"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7180,13 +7026,13 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4e06086ea1c118f1603cba84c44a986b8132f54c51a710f72e0b4c9773bc3b5"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7196,17 +7042,17 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6daeb4ce9471d306aab7a7f9b356643eb646df0be6306e241e499be442fe44da"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7216,13 +7062,13 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f925341a47c6c95f02e30af26d478014d8b6885193169e5ce0869b75eb5b05d8"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7233,16 +7079,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a971ac06fcaa8b0e895c881e879e3c333f77bd79d1480fdffcc5b6e74750181"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7252,13 +7098,13 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84013a3fa1fb5553c840fc0b6d165448e0765b39ef7197b1ddf8b22f367b2f37"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7269,14 +7115,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9373a0c1386cf48e6e5f0e123fe67cc933e72e32d8fb05457ee7a48a96d53bef"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -7287,21 +7133,21 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9170fef289c193773d94e2b6c799f09c97b199464902a8d220bfcd399a65d726"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
- "sp-state-machine 0.41.0",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 35.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -7310,14 +7156,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68db2e88494745b73e4e774326f7d39e0dbdf35f8b79e70d134f2d99fd0ecb"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
 ]
@@ -7328,16 +7174,16 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e945ae7db25c0fa77c65882fb7138ce88a28fe08f151a539ea51a115b9595137"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7347,10 +7193,10 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a563877abd32f7f3885d6437c196ba9adf1cfbc430afcc4059e6ede7ff354f38"
 dependencies = [
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7358,10 +7204,10 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 36.0.0",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -7394,8 +7240,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc26b2f096e83fd919d8d6bb586963f2374b513a7c17fe356e67f585c88943b8"
 dependencies = [
  "parity-scale-codec",
- "sp-api 32.0.0",
- "sp-staking 32.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7404,15 +7250,15 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "204af00c1b72938db6a2d05b2dc6d1576f5957a9a9ec022ea6b5003f400f337c"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7423,13 +7269,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc1377f434c84a4afc3888dee27a01a0720c3fe77486f9dfb2e7310e6ad6b0b"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7440,15 +7286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b43a57df90499460bf6645fd19390c8ae85bb225566c40e36cc8e2f4663b3f6"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -7460,34 +7306,17 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d451009c9a104acedb2b93aeb31096f93cfa4f39873f4b5a01d36bb3735c299"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
-dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7497,14 +7326,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373788faa2053bb2f6441921599ea06de81cdff0f96fcd1e6a2e021aa1296f72"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7517,11 +7346,11 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7531,10 +7360,10 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5362418d8a4ec0bf93773d79f5fc88d6533c5bb9939e495db7072d8db4dc1d"
 dependencies = [
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7545,16 +7374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b88e19f21e3ddec95df10b3f9411c801733f2e0a8185a7ed18ef17e98951fa2"
 dependencies = [
  "docify",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7564,14 +7393,14 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb9f2e5a8595de607cfb062e0c115fadce3034c902b843f8f41636376a08d0a"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7581,13 +7410,13 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8205beed2e075ef3d3651bb806d39fda894861e8e82807e42553d499d5e552f6"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7597,13 +7426,13 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebeaf4774a0c69823a35560daea3642b98a5fc12432ce92efc0dd22b491e2dc7"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -7614,21 +7443,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5697c6ac29c8dd2e96d895ba6fe64b969fdcc5a5ab8cf6fa83240a519b2460"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "xcm-fee-payment-runtime-api",
 ]
 
@@ -7638,18 +7467,18 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48a95a496f4c2ce2c7b9318584f7e7c589efe456be161ad373144d8e356be6ac"
 dependencies = [
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -7668,7 +7497,7 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "docify",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7696,16 +7525,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
  "sp-timestamp",
- "staging-xcm 13.0.1",
+ "staging-xcm",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -7725,10 +7554,10 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7736,38 +7565,38 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core 33.0.1",
- "sp-genesis-builder 0.13.0",
- "sp-inherents 32.0.0",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version 35.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -7779,13 +7608,13 @@ checksum = "d4a8836c0b86d76631b19fcc5daeb93c028c947a872fba0b1cd9621c0cf031be"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7793,13 +7622,13 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-consensus-aura",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-parachain-info",
- "staging-xcm 13.0.1",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -8166,8 +7995,8 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "schnellru",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-core",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]
@@ -8226,11 +8055,11 @@ dependencies = [
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
 ]
@@ -8250,25 +8079,12 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "thiserror",
  "tokio-util",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3c192d31bad69f561437549b3619a6cf02eae51d7f331efef7cfc6a56d61c2"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 32.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
 ]
 
 [[package]]
@@ -8279,8 +8095,8 @@ checksum = "4fed6798f76290be654149afd585cfef09bf796990b68c79d7ee5e5110a04d15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -8304,8 +8120,8 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto 36.0.0",
- "sp-keystore 0.39.0",
+ "sp-application-crypto",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]
@@ -8320,8 +8136,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
- "sp-core 33.0.1",
- "sp-trie 35.0.0",
+ "sp-core",
+ "sp-trie",
  "thiserror",
 ]
 
@@ -8341,10 +8157,10 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "tracing-gum",
 ]
 
@@ -8385,7 +8201,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-maybe-compressed-blob",
  "thiserror",
  "tracing-gum",
@@ -8417,10 +8233,10 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
  "tracing-gum",
 ]
@@ -8464,7 +8280,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]
@@ -8479,7 +8295,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
  "wasm-timer",
@@ -8501,7 +8317,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -8573,7 +8389,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 32.0.0",
+ "sp-inherents",
  "thiserror",
  "tracing-gum",
 ]
@@ -8629,16 +8445,16 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 13.0.0",
+ "polkadot-core-primitives",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "rand 0.8.5",
  "slotmap",
- "sp-core 33.0.1",
+ "sp-core",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8657,7 +8473,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]
@@ -8674,16 +8490,16 @@ dependencies = [
  "libc",
  "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
  "sc-executor-wasmtime",
  "seccompiler",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io 36.0.0",
+ "sp-io",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8720,7 +8536,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "sc-network-types 0.11.0",
- "sp-core 33.0.1",
+ "sp-core",
  "thiserror",
  "tokio",
 ]
@@ -8766,7 +8582,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types 0.11.0",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8782,16 +8598,16 @@ dependencies = [
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-core",
+ "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
  "zstd 0.12.4",
 ]
@@ -8828,11 +8644,11 @@ dependencies = [
  "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8866,9 +8682,9 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror",
  "tracing-gum",
 ]
@@ -8890,28 +8706,10 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ecbe3c247ca2201e231801111ff4739fb1d66eb1421c2e5c0a2b153ac87b5"
-dependencies = [
- "bounded-collections",
- "derive_more",
- "parity-scale-codec",
- "polkadot-core-primitives 12.0.0",
- "scale-info",
- "serde",
- "sp-core 32.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
- "sp-weights",
 ]
 
 [[package]]
@@ -8923,11 +8721,11 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives 13.0.0",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
 ]
@@ -8942,21 +8740,21 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 13.0.0",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -8983,13 +8781,13 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -9001,17 +8799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1215fb26c995f9a2ac815c28498e90347373d868f9e07bb8f180ea607a678108"
 dependencies = [
  "bitvec",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -9020,7 +8818,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -9031,18 +8829,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -9053,7 +8851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54a84f56cf84685008ef66eb85d7ce6d87511b9c21a38ab214bbdd2917ae93f"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -9069,15 +8867,15 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -9085,8 +8883,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives 13.0.0",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand 0.8.5",
@@ -9094,19 +8892,19 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
- "staging-xcm 13.0.1",
- "staging-xcm-executor 13.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -9118,10 +8916,10 @@ checksum = "1cd7113642afd582260667a50d550378310fb68be3991316eda3ab3c82a37ccc"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -9132,7 +8930,7 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -9142,7 +8940,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 13.0.0",
+ "polkadot-core-primitives",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -9167,7 +8965,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
@@ -9200,7 +8998,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9208,22 +9006,22 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.41.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version 35.0.0",
+ "sp-version",
  "sp-weights",
- "staging-xcm 13.0.1",
+ "staging-xcm",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
@@ -9249,8 +9047,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore 0.39.0",
- "sp-staking 32.0.0",
+ "sp-keystore",
+ "sp-staking",
  "thiserror",
  "tracing-gum",
 ]
@@ -9263,7 +9061,7 @@ checksum = "9b9b54c9dbd043cdf485a5e0c2718892fe5c64e6114e2d1ce578fb33605b7c2e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-core 33.0.1",
+ "sp-core",
  "tracing-gum",
 ]
 
@@ -10197,10 +9995,10 @@ checksum = "5f09353883a98e00d2d8e1e834afa8f8d4fe56f00179843c9b88226db38577ef"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10210,7 +10008,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -10243,7 +10041,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -10252,7 +10050,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -10262,29 +10060,29 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core 33.0.1",
- "sp-genesis-builder 0.13.0",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 35.0.0",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-fee-payment-runtime-api",
@@ -10296,15 +10094,15 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f07e4b8066110a58d9e6290b5f5ff189684495a0ae8c4b07eca5f5b8d1353595"
 dependencies = [
- "frame-support 34.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -10594,7 +10392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f01218e73ea57916be5f08987995ac802d6f4ede4ea5ce0242e468c590e4e2"
 dependencies = [
  "log",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-wasm-interface",
  "thiserror",
 ]
@@ -10621,12 +10419,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types 0.11.0",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10645,12 +10443,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10661,13 +10459,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c1a029e5f794a859bbda434bb311660fe195106e5ec6147e460bb9dffb3baf"
 dependencies = [
  "parity-scale-codec",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-trie 35.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10689,12 +10487,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.13.0",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-tracing",
 ]
 
@@ -10742,12 +10540,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-keyring",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "sp-panic-handler",
- "sp-runtime 37.0.0",
- "sp-version 35.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
 ]
@@ -10766,17 +10564,17 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
  "sp-storage",
- "sp-trie 35.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10800,11 +10598,11 @@ dependencies = [
  "schnellru",
  "sp-arithmetic",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-database",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
- "sp-trie 35.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10823,12 +10621,12 @@ dependencies = [
  "sc-network-types 0.11.0",
  "sc-utils",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10848,17 +10646,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10884,18 +10682,18 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-inherents 32.0.0",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10912,14 +10710,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10944,16 +10742,16 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types 0.11.0",
  "sc-utils",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10975,8 +10773,8 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-consensus-beefy",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10991,7 +10789,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11000,7 +10798,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453c5b758a15d8addfd4874fa370a4dd14a4e3e5911dc663da6f384f4d8090fd"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "array-bytes",
  "async-trait",
  "dyn-clone",
@@ -11025,16 +10823,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -11055,8 +10853,8 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11078,10 +10876,10 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -11096,14 +10894,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-core",
  "sp-externalities",
- "sp-io 36.0.0",
+ "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie 35.0.0",
- "sp-version 35.0.0",
+ "sp-trie",
+ "sp-version",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -11168,7 +10966,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11180,9 +10978,9 @@ dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror",
 ]
 
@@ -11207,12 +11005,12 @@ dependencies = [
  "sc-network",
  "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-core",
+ "sp-keystore",
  "sp-mixnet",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11256,8 +11054,8 @@ dependencies = [
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11284,7 +11082,7 @@ dependencies = [
  "sc-network-types 0.10.0",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 37.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11293,7 +11091,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "962b37f9939ea0d678219cd4beae5b604b2ee2836e670c14fe3d347e21d57790"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "futures",
  "futures-timer",
  "libp2p",
@@ -11303,7 +11101,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types 0.11.0",
  "schnellru",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11325,8 +11123,8 @@ dependencies = [
  "sc-network",
  "sc-network-types 0.11.0",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11360,8 +11158,8 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11385,7 +11183,7 @@ dependencies = [
  "sc-network-types 0.11.0",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11445,12 +11243,12 @@ dependencies = [
  "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-core",
  "sp-externalities",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "sp-offchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -11485,16 +11283,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
+ "sp-core",
+ "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
- "sp-version 35.0.0",
+ "sp-version",
  "tokio",
 ]
 
@@ -11512,10 +11310,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 37.0.0",
- "sp-version 35.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
 ]
 
@@ -11562,12 +11360,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 37.0.0",
- "sp-version 35.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11615,20 +11413,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.41.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 35.0.0",
- "sp-version 35.0.0",
+ "sp-trie",
+ "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11647,7 +11445,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 33.0.1",
+ "sp-core",
 ]
 
 [[package]]
@@ -11659,7 +11457,7 @@ dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core 33.0.1",
+ "sp-core",
  "thiserror",
  "tokio",
 ]
@@ -11680,7 +11478,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11700,9 +11498,9 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-io 36.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -11746,11 +11544,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11787,11 +11585,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11810,8 +11608,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11872,7 +11670,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -12283,7 +12081,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -12335,7 +12133,7 @@ dependencies = [
  "chacha20",
  "crossbeam-queue",
  "derive_more",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "either",
  "event-listener 2.5.3",
  "fnv",
@@ -12471,29 +12269,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b500647cfe266d58781f44af9b13c3bd57fb3be08642f2a9f13e024cc5e22359"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro",
- "sp-core 32.0.0",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime 36.0.0",
- "sp-runtime-interface",
- "sp-state-machine 0.40.0",
- "sp-std",
- "sp-trie 34.0.0",
- "sp-version 34.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "sp-api"
 version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84f09c4b928e814e07dede0ece91f1f6eae1bff946a0e5e4a76bed19a095f1"
@@ -12503,15 +12278,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-state-machine 0.41.0",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 35.0.0",
- "sp-version 35.0.0",
+ "sp-trie",
+ "sp-version",
  "thiserror",
 ]
 
@@ -12532,20 +12307,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57541120624a76379cc993cbb85064a5148957a92da032567e54bce7977f51fc"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "296282f718f15d4d812664415942665302a484d3495cf8d2e2ab3192b32d2c73"
@@ -12553,8 +12314,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
 ]
 
@@ -12582,9 +12343,9 @@ checksum = "7c06b0d26bcc9b5db298c4e270fdff286411912af51bc0d9ef7d04f139ee3146"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12593,9 +12354,9 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329e1cfb98f113d91d0db80a6e984cbb7e990f03ef599a8dc356723a47d40509"
 dependencies = [
- "sp-api 32.0.0",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12609,11 +12370,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-database",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12626,10 +12387,10 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12642,11 +12403,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12660,12 +12421,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12679,14 +12440,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing",
- "sp-io 36.0.0",
- "sp-keystore 0.39.0",
+ "sp-io",
+ "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12701,11 +12462,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12722,53 +12483,6 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
-dependencies = [
- "array-bytes",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58 0.5.1",
- "dyn-clonable",
- "ed25519-zebra 3.1.0",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.10.5",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel 0.11.4",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "ss58-registry",
- "substrate-bip39",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
 version = "33.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3368e32f6fda6e20b8af51f94308d033ab70a021e87f6abbd3fed5aca942b745"
@@ -12779,7 +12493,7 @@ dependencies = [
  "bounded-collections",
  "bs58 0.5.1",
  "dyn-clonable",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "futures",
  "hash-db",
  "hash256-std-hasher",
@@ -12873,19 +12587,6 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7605a8ed2c06d348c26055b7907c3d2d62f984666e9025b57df4895f865f5901"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 31.0.0",
- "sp-runtime 36.0.0",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb26e3653f6a2feac2bcb2749b5fb080e4211b882cafbdba86e4304c03c72c8"
@@ -12893,22 +12594,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170537049d57fc645637e4586fe98a3291392b2ecfd7988ea31639cf43470b42"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 36.0.0",
- "thiserror",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12921,35 +12608,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b64ab18a0e29def6511139a8c45a59c14a846105aab6f9cc653523bd3b81f55"
-dependencies = [
- "bytes",
- "ed25519-dalek 2.1.1",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive",
- "rustversion",
- "secp256k1",
- "sp-core 32.0.0",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore 0.38.0",
- "sp-runtime-interface",
- "sp-state-machine 0.40.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 34.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -12966,15 +12626,15 @@ dependencies = [
  "polkavm-derive",
  "rustversion",
  "secp256k1",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-keystore 0.39.0",
+ "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine 0.41.0",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie 35.0.0",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -12985,21 +12645,9 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65a24506e9e7c4d66e3b4d9c45e35009b59d3cc545481224bf1e85146d2426ec"
 dependencies = [
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "strum 0.26.2",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c7a7abd860a5211a356cf9d5fcabf0eb37d997985e5d722b6b33dcc815528"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 32.0.0",
- "sp-externalities",
 ]
 
 [[package]]
@@ -13010,7 +12658,7 @@ checksum = "92a909528663a80829b95d582a20dd4c9acd6e575650dee2bcaf56f4740b305e"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
 ]
 
@@ -13043,8 +12691,8 @@ checksum = "a1ac523987a20ae4df607dcf1b7c7728b1f7b77f016f27413203e584d22ffde3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -13058,10 +12706,10 @@ dependencies = [
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-core",
  "sp-debug-derive",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13075,8 +12723,8 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13085,9 +12733,9 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e7bdda614cb69c087d89d598ac4850e567be09f3de8d510b57147c111d5ce1"
 dependencies = [
- "sp-api 32.0.0",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13109,32 +12757,7 @@ checksum = "6f7b352143ee888fc624adff978e32b2ee6cf81d659907190107e1c86e205eeb"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core 33.0.1",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 35.0.0",
- "sp-arithmetic",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-std",
- "sp-weights",
+ "sp-core",
 ]
 
 [[package]]
@@ -13155,10 +12778,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 36.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-io",
  "sp-std",
  "sp-weights",
 ]
@@ -13205,25 +12828,11 @@ checksum = "601e0203c52ac7c1122ad316ae4e5cc355fdf1d69ef5b6c4aa30f7a17921fad9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-core 33.0.1",
- "sp-keystore 0.39.0",
- "sp-runtime 37.0.0",
- "sp-staking 32.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd38abe12a12b0c24d318011ec3cd3280f8d828666994695a6c0652f38662dbf"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 32.0.0",
- "sp-runtime 36.0.0",
+ "sp-api",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13236,29 +12845,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18084cb996c27d5d99a88750e0a8eb4af6870a40df97872a5923e6d293d95fb9"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "smallvec",
- "sp-core 32.0.0",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie 34.0.0",
- "thiserror",
- "tracing",
- "trie-db",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13273,10 +12861,10 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "smallvec",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie 35.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
  "trie-db",
@@ -13296,12 +12884,12 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
- "sp-core 33.0.1",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -13334,8 +12922,8 @@ checksum = "1d48d9246310340b11dc4f4c119fe93975c7c0c325637693da8c755d028fce19"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13357,8 +12945,8 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14de2a91e5a2bebaf47993644643c92564cafc55d55e1c854f6637ee62c90b4b"
 dependencies = [
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13370,34 +12958,10 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 33.0.1",
- "sp-inherents 32.0.0",
- "sp-runtime 37.0.0",
- "sp-trie 35.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87727eced997f14d0f79e3a5186a80e38a9de87f6e9dc0baea5ebf8b7f9d8b66"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 32.0.0",
- "sp-externalities",
- "thiserror",
- "tracing",
- "trie-db",
- "trie-root",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -13406,7 +12970,7 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61ab0c3e003f457203702e4753aa5fe9e762380543fada44650b1217e4aa5a5"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "hash-db",
  "lazy_static",
  "memory-db",
@@ -13416,30 +12980,12 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 33.0.1",
+ "sp-core",
  "sp-externalities",
  "thiserror",
  "tracing",
  "trie-db",
  "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8e3856686aa2719b1c05af07ba7e6021d844944472f246f3b5f1c585be04cd"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 36.0.0",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror",
 ]
 
 [[package]]
@@ -13454,7 +13000,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13559,31 +13105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0473f6e6cd7296675188f88b2c29dccea328f9f88ccb18f3a79048505ce7dc2a"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "staging-xcm"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5090e0801a8aeb28ff88cc6e0ca0bad399cc58eed11ec70c517fcb316bd3151b"
-dependencies = [
- "array-bytes",
- "bounded-collections",
- "derivative",
- "environmental",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-weights",
- "xcm-procedural",
 ]
 
 [[package]]
@@ -13607,70 +13134,25 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
-dependencies = [
- "frame-support 33.0.0",
- "frame-system 33.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-transaction-payment 33.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 11.0.0",
- "scale-info",
- "sp-arithmetic",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
- "sp-weights",
- "staging-xcm 12.0.0",
- "staging-xcm-executor 12.0.0",
-]
-
-[[package]]
-name = "staging-xcm-builder"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd94fb9634d6276b74b7ee9ec5b761c52c30ec40b7c0a381711c5d25c3a0141"
 dependencies = [
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 13.0.1",
- "staging-xcm-executor 13.0.0",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
-dependencies = [
- "environmental",
- "frame-benchmarking 33.0.0",
- "frame-support 33.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core 32.0.0",
- "sp-io 35.0.0",
- "sp-runtime 36.0.0",
- "sp-std",
- "sp-weights",
- "staging-xcm 12.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -13680,19 +13162,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcd7135969e580a14b73bf65fd25d714f3b20c3b2e94ff0949c148820ab3a79d"
 dependencies = [
  "environmental",
- "frame-benchmarking 34.0.0",
- "frame-support 34.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core 33.0.1",
- "sp-io 36.0.0",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 13.0.1",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -13861,11 +13343,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 32.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13892,10 +13374,10 @@ dependencies = [
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
- "sp-state-machine 0.41.0",
- "sp-trie 35.0.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
  "trie-db",
 ]
 
@@ -15349,11 +14831,11 @@ checksum = "01b641fb4783e441a32ddc3e3f7927a6092cec39af9de2f85becacba412b6815"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 34.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support 34.0.0",
- "frame-system 34.0.1",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -15364,7 +14846,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances 35.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -15401,7 +14883,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 34.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -15410,7 +14892,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 12.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -15419,30 +14901,30 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 32.0.0",
- "sp-application-crypto 36.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-core 33.0.1",
- "sp-genesis-builder 0.13.0",
- "sp-inherents 32.0.0",
- "sp-io 36.0.0",
+ "sp-core",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 37.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 32.0.0",
+ "sp-staking",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 35.0.0",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
- "staging-xcm-executor 13.0.0",
+ "sp-version",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-fee-payment-runtime-api",
@@ -15454,15 +14936,15 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55241a1b789ae6acf4bbe62687f2876fa83b151abf3d94e275c92ba4a2b59fe8"
 dependencies = [
- "frame-support 34.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core 33.0.1",
- "sp-runtime 37.0.0",
+ "sp-core",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 13.0.1",
- "staging-xcm-builder 13.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -15885,14 +15367,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08b02854d1e3f844dec37dcf5897524f8e7ac6f227d225cba4ab43dadd0b691"
 dependencies = [
- "frame-support 34.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 32.0.0",
- "sp-runtime 37.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
  "sp-weights",
- "staging-xcm 13.0.1",
+ "staging-xcm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,11 +23,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "gimli 0.28.1",
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -206,20 +206,6 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
@@ -229,7 +215,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -363,12 +349,6 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
-
-[[package]]
-name = "array-bytes"
 version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
@@ -419,7 +399,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -457,16 +437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy 0.5.2",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite 0.2.14",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -509,17 +489,17 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.0",
+ "polling 3.7.2",
  "rustix 0.38.34",
  "slab",
  "tracing",
@@ -537,12 +517,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "pin-project-lite 0.2.14",
 ]
 
@@ -576,12 +556,12 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
+checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
 dependencies = [
- "async-io 2.3.2",
- "async-lock 3.3.0",
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -606,7 +586,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -642,16 +622,16 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
- "addr2line 0.21.0",
+ "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.32.2",
+ "object 0.36.0",
  "rustc-demangle",
 ]
 
@@ -737,7 +717,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -882,12 +862,11 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
  "async-channel 2.3.1",
- "async-lock 3.3.0",
  "async-task",
  "futures-io",
  "futures-lite 2.3.0",
@@ -917,14 +896,14 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0181e1058f555b2e0f177e82042a6edd9c342ed4ec826376b2e5aa1cd29fc853"
+checksum = "b493c8238552fb50edfe9c3eb94e8058fce36cce71cc9ad0fb1902d3aedcd902"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -1042,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -1176,19 +1155,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-merkle-mountain-range"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ccb671c5921be8a84686e6212ca184cb1d7c51cadcdbfcbd1cc3f042f5dfb8"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1197,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1207,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1220,21 +1190,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "coarsetime"
@@ -1275,7 +1245,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1301,7 +1271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum_macros 0.26.4",
  "unicode-width",
 ]
 
@@ -1652,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af3de66b0512db180c091ccbf673ed198f75a25b602289ee247251bf966c39"
+checksum = "85253f32659117ed1f4aa213e3257dcc022be89f091be91dc83993de5ed8d060"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1663,40 +1633,40 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeaa7ba76cb14097c15105674be6ec74e58bc1313cb322a97e038c9abfbf09c4"
+checksum = "d6197f6736982d38c34ee006f3bb71760a52dd87fdbc65798088c2916d18469d"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999414a27e99ed73f447aba5f9382bb81fbf3e98a8c1a8874f71f929d094759"
+checksum = "c04552e4aa9eaa59be930ee23a910f0c41ba3e6d9e725cc21808c11fe8eb8f09"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1719,17 +1689,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1737,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc06ef9519e39f72915033e0aec418383707290103c8d9ba8ffbc70ddfd515e7"
+checksum = "81828c28d9a38669f45420d31d18580760381ae86e1b2ecd2a426f1e57ce74fb"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1757,59 +1727,59 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-timestamp",
- "sp-trie",
+ "sp-trie 35.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a533049ee548528aada1c09c5827c3a2fd8cce96ecb4ff1fca241abfef87ba"
+checksum = "bbf30d94b3abfd99cef2e99ce0314bcd4f17d973bc02cee867f32171644a8191"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1da1f0f7be1258a0f1a4a43ca0dd4a1add8e2e639dceaf310fc136d6835fe00"
+checksum = "afcfd3ecd531f3f8a83c6d39715e6e1804cb70da0d162706c0e82de90003407b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5426870af0eac3277135aac62dafea82f9c42b501193bca5483c2eb9358b5b"
+checksum = "69fd3787124724561055fe7178866120ecf47e30f72d90ef9299233d74e32a66"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1819,22 +1789,22 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
  "sp-storage",
- "sp-trie",
+ "sp-trie 35.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286e7071e367a4ee6f1e9c674a27118c6f04ef273b94194082b8155255451503"
+checksum = "bc3fc23f6dc74dc346bee76554b581d72ffe5bbe2b26d44a210559012c9732e0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1851,15 +1821,15 @@ dependencies = [
  "sc-consensus",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a909ed00f0280a9f53838616bb8f56b180116838a8242b847a18c8950e7cc4ec"
+checksum = "c1cb06d29f61d047814a32070014ad259dae1ec0a4426c9474991952de8b21d7"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1884,39 +1854,39 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2703d49952e0538c4d05fe1f1114e62741871693e862fc68ab56ae6b3b5230"
+checksum = "98aaa88ee4435475935579907b03e4f60b086c6878945868a4d4e31510957431"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249e7657ac378241ae6c437df851bbe0971d93df756d1201315395b5ce856974"
+checksum = "d9224798d18e22f3847b2d513dcb8db5611f8ddd62813da81154f9cfe95c2d78"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1924,27 +1894,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
- "sp-trie",
- "sp-version",
- "staging-xcm",
+ "sp-trie 35.0.0",
+ "sp-version 35.0.0",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
  "trie-db",
 ]
 
@@ -1957,173 +1928,174 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be9d77e00ad1dbcf12dcd81c2758d651adf6e3072f3cb51c11d8739426f4cbb"
+checksum = "e4f32808caa41da9a1db60e1de9e7ba84eb7370067f481ecc7ceb137aede0ac5"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7737eb5d81bcd79df114e711927ba19c2dbd312f245ae03b76d330abb3506d"
+checksum = "e3bfe7a26ebf90b71ab9cb75f983f29d9a2a47205fabde8ad6d8589c629f1851"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "staging-xcm",
+ "staging-xcm 13.0.1",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2939bc9749f4a5299ae20f7756ce69ce3e63f72ed936d7f1db0189187f70a1"
+checksum = "d89d7c1ee618846a05153082bb30408ef574227899d2b3d20ec1dd234649a076"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61fa5dad966e340092a4521b56b43dddce5bf466ddb07d9a01c534e63e4e0b7"
+checksum = "35269d04c8b6a775be07c49e5512f383d455bb91fe951adef8c72d45600a9acd"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 13.0.0",
  "polkadot-primitives",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad51d36ea156ef84d7e8ca5cea881867d3540e8dfdb8ea6b9d2b9190197a22a5"
+checksum = "a8947e8b09cef060025d11a8da171f698da4d9b67191b5bc3f96d6cec553f17d"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 13.0.0",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "sp-trie",
- "staging-xcm",
+ "sp-trie 35.0.0",
+ "staging-xcm 13.0.1",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d358b1c4062048e47635b49d066131e4eef6314c0e81501d4c9c2e028dbc4"
+checksum = "698272736111f59f0b8c88cfa8586ef943b355958da683676e753af9f351a06a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e736734a6b4b0308d931756c30c3472fa5ec99a95be14f70567f25c97b3822cc"
+checksum = "f815c73e6d8a5b44daac8881770137a99364d4c531ae9a21b2e6909a889631f1"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68201ff0845be29c3c0e7e408e5f9d4de0e01b55787fe2c8709e658cbd2c937"
+checksum = "8d48fbf5b0f5b43df5811fdf3efd5c16517960885e51e7de79bf3f7def8c25b9"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee70eb2f55d20a965e3538fc96aac2801815af510b4460e8a5783f5197e0872"
+checksum = "3195604b37c3de5407201cf77deabb4436a6ddb2db6206bc72aa6a356402532e"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
+ "frame-support 34.0.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9557dc83e9fa1ab863f6070f9d325a8075cb00478f2a756132ed87b4e3a29ed"
+checksum = "e10278c5ed258ba0ca63cfa103cacc3d15b95f2b0044557a57653188ef76d5e3"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2137,18 +2109,18 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed3c0bd4319881da5f94b77380db377499e129a176184430b308d9d7bd1d9a8"
+checksum = "0dfb9dc86a639df592a99272aadd6bcba50ba4d183c35525c32e0c8b33f085bd"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2157,28 +2129,28 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-state-machine",
+ "sp-state-machine 0.41.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ffcf7b86d4a140ba5ba6c94537ae54334c594bb4cf7a6464c848859b7970d1"
+checksum = "dcd2da7aef1dfb8257ba4358cb7f41d032361417db10835bf8cff00e2a781fc6"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 13.0.0",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-chain-api",
@@ -2196,11 +2168,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2208,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800d957241a91a58b55a3ee9f607caea2660a01d2fcfc285bdcec262a3d8882d"
+checksum = "ab70504899cac7553fd5866586e4a5229c6da52091be78893271e0c1972064ad"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2231,14 +2203,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-storage",
- "sp-version",
+ "sp-version 35.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2248,17 +2220,17 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f509dfa3d3380fd0023f4cbd15bfeccd333de8d0140f85d13e6b295fb53dd7"
+checksum = "09720b54033b0f2ee3d254a90cfecf62a46db5c8ce16cc893218e7662662d507"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
@@ -2299,7 +2271,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2317,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb497fad022245b29c2a0351df572e2d67c1046bcef2260ebc022aec81efea82"
+checksum = "273dcfd3acd4e1e276af13ed2a43eea7001318823e7a726a6b3ed39b4acc0b82"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2329,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9327c7f9fbd6329a200a5d4aa6f674c60ab256525ff0084b52a889d4e4c60cee"
+checksum = "d8b2766fbd92be34e9ed143898fce6c572dc009de39506ed6903e5a05b68914e"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2339,24 +2311,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c799a4a846f1c0acb9f36bb9c6272d9b3d9457f3633c7753c6057270df13c"
+checksum = "839fcd5e43464614ffaa989eaf1c139ef1f0c51672a1ed08023307fa1b909ccd"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bc249a7e3cd554fd2e8e08a426e9670c50bbfc9a621653cfa9accc9641783"
+checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2461,20 +2433,20 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2563,7 +2535,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2587,9 +2559,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.66",
  "termcolor",
- "toml 0.8.13",
+ "toml 0.8.14",
  "walkdir",
 ]
 
@@ -2783,27 +2755,27 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2814,7 +2786,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2871,33 +2843,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.14",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite 0.2.14",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
  "pin-project-lite 0.2.14",
 ]
 
@@ -2907,7 +2858,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.3.0",
+ "event-listener 5.3.1",
  "pin-project-lite 0.2.14",
 ]
 
@@ -2922,28 +2873,17 @@ dependencies = [
 
 [[package]]
 name = "expander"
-version = "0.0.4"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a718c0675c555c5f976fff4ea9e2c150fa06cefa201cadef87cfbf9324075881"
-dependencies = [
- "blake3",
- "fs-err",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "expander"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e83c02035136f1592a47964ea60c05a50e4ed8b5892cfac197063850898d4d"
+checksum = "e2c470c71d91ecbd179935b24170459e926382eaaa86b590b78814e180d8a8e2"
 dependencies = [
  "blake2 0.10.6",
+ "file-guard",
  "fs-err",
- "prettier-please",
+ "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2975,9 +2915,9 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fatality"
-version = "0.0.6"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad875162843b0d046276327afe0136e9ed3a23d5a754210fb6f1f33610d39ab"
+checksum = "ec6f82451ff7f0568c6181287189126d492b5654e30a788add08027b6363d019"
 dependencies = [
  "fatality-proc-macro",
  "thiserror",
@@ -2985,17 +2925,16 @@ dependencies = [
 
 [[package]]
 name = "fatality-proc-macro"
-version = "0.0.6"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5aa1e3ae159e592ad222dc90c5acbad632b527779ba88486abe92782ab268bd"
+checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
- "expander 0.0.4",
- "indexmap 1.9.3",
- "proc-macro-crate 1.3.1",
+ "expander",
+ "indexmap 2.2.6",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "thiserror",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3023,6 +2962,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "file-guard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ef72acf95ec3d7dbf61275be556299490a245f017cf084bd23b4f68cf9407c"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "file-per-thread-logger"
@@ -3058,7 +3007,7 @@ dependencies = [
  "log",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "scale-info",
 ]
 
@@ -3140,6 +3089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,20 +3110,46 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f963589fa0f5ef5fe87fad5a9ac9ec4a43d83fd63e1993024576a8dcaee5e228"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-support-procedural 28.0.0",
+ "frame-system 33.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-application-crypto 35.0.0",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130b79108bca3d8850e850c276f1012058593d6a2a8774132e72766245bbcacc"
+dependencies = [
+ "frame-support 34.0.0",
+ "frame-support-procedural 29.0.1",
+ "frame-system 34.0.1",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3173,21 +3158,21 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13ce497c53ed3a9aadadfc3ea7904b00717965156c0e2e6dd16fc049a379cd7"
+checksum = "13238d7648598b5476ddbf87c8633eb299c1f872e93c9afc874a1419e6e990d2"
 dependencies = [
  "Inflector",
- "array-bytes 6.2.3",
+ "array-bytes",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "gethostname",
  "handlebars",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "linked-hash-map",
  "log",
@@ -3204,19 +3189,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.13.0",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 35.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3231,43 +3216,43 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6e46fd5f6bbbce22fcb19bccce899b4e83e917ba5181b1adae94abb086f124"
+checksum = "74e498d8b21ba927024302645e0f4d0d0136c9620808d8425bb309fb8a92d3ff"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d5b1ec42b019aa16d1f9269f74f391c32ce642cb2aad7b1b6a6d65a34e1bc6"
+checksum = "f5ab937cea917f5875b0e08d55ed941f9c82c2b08628d6bf47b90c63c48ef607"
 dependencies = [
- "aquamarine 0.3.3",
- "frame-support",
- "frame-system",
+ "aquamarine",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -3285,34 +3270,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata-hash-extension"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51ead97e4ac8fdd3b62258bf5f97d2d82412ec0386388ce8296aa23d561536f"
-dependencies = [
- "array-bytes 6.2.3",
- "docify",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
-]
-
-[[package]]
 name = "frame-support"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d04fc1fdbc7bdcb1cb54834e16a5194e5a16a25bfdaca1b761ee9ff4963366f"
 dependencies = [
- "aquamarine 0.5.0",
- "array-bytes 6.2.3",
+ "aquamarine",
+ "array-bytes",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 28.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3323,18 +3292,60 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 31.0.0",
  "sp-arithmetic",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.12.0",
+ "sp-inherents 31.0.0",
+ "sp-io 35.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 36.0.0",
+ "sp-staking 31.0.0",
+ "sp-state-machine 0.40.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c177377726d7bb598dd942e38168c1eb6872d53810a6bf810f0a428f9a46be8"
+dependencies = [
+ "aquamarine",
+ "array-bytes",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 29.0.1",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 32.0.0",
+ "sp-arithmetic",
+ "sp-core 33.0.1",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.13.0",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -3351,7 +3362,7 @@ dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse 0.2.0",
- "expander 2.1.0",
+ "expander",
  "frame-support-procedural-tools",
  "itertools 0.10.5",
  "macro_magic",
@@ -3359,7 +3370,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.65",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f822826825d810d0e096e70493cbc1032ff3ccf1324d861040865635112b6aa"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse 0.2.0",
+ "expander",
+ "frame-support-procedural-tools",
+ "itertools 0.11.0",
+ "macro_magic",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3372,7 +3403,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3383,7 +3414,7 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3394,55 +3425,76 @@ checksum = "64265317899a2ecfc465a1ab55fa3094dbbbc7061292592fdbbb8acc136c4735"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "sp-version",
+ "sp-version 34.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "frame-system"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85777d5cb78d8f244aa4e92a06d13c234f7980dd7095b1baeefc23a5945cad6c"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 34.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-std",
+ "sp-version 35.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a23446bf524bcc64351ecc5a50925debdc92d50a0b8384c3064dc13b3c64ca3"
+checksum = "b2df1ebcb669ae29aec03f6f87b232f2446942fb79fad72434d8d0a0fd7df917"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54771ae481dd08825d4de28b1b3623163efd9e7c4b59a6db1fb048dcdf73789e"
+checksum = "bd92e3fe18b93d456efdabbd98070a1d720be5b6affe589379db9b7d9272eba5"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 32.0.0",
 ]
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f542a58bd43234882faff12062ce94838b3bbca1b6ed6b32180ee153350905f"
+checksum = "748a6c8286447388ff7a35d88fc2e0be3b26238c609c88b7774615c274452413"
 dependencies = [
- "frame-support",
+ "frame-support 34.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
@@ -3566,7 +3618,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3719,6 +3771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,7 +3794,7 @@ dependencies = [
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
  "rand 0.8.5",
@@ -3860,6 +3918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,9 +4030,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -3984,9 +4048,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4046,6 +4110,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,12 +4250,14 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -4092,7 +4276,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io 2.3.2",
+ "async-io 2.3.3",
  "core-foundation",
  "fnv",
  "futures",
@@ -4136,18 +4320,18 @@ dependencies = [
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "include_dir_macros",
 ]
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4219,7 +4403,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4254,7 +4438,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4374,7 +4558,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
  "rustc-hash",
@@ -4396,7 +4580,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4494,7 +4678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7a85fe66f9ff9cd74e169fdd2c94c6e1e74c412c99a73b4df3200b5d3760b2"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -4505,7 +4689,7 @@ checksum = "b644c70b92285f66bfc2032922a79000ea30af7bc2ab31902992a5dcb9b434f6"
 dependencies = [
  "kvdb",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "regex",
  "rocksdb",
  "smallvec",
@@ -4630,7 +4814,7 @@ dependencies = [
  "multihash 0.17.0",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
@@ -4650,7 +4834,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "smallvec",
  "trust-dns-resolver 0.22.0",
 ]
@@ -4812,7 +4996,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "quinn-proto",
  "rand 0.8.5",
  "rustls 0.20.9",
@@ -4928,7 +5112,7 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "quicksink",
  "rw-stream-sink",
  "soketto",
@@ -5024,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5097,6 +5281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "litep2p"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,10 +5307,10 @@ dependencies = [
  "multihash 0.17.0",
  "network-interface",
  "nohash-hasher",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "prost 0.11.9",
- "prost-build",
+ "prost-build 0.11.9",
  "quinn",
  "rand 0.8.5",
  "rcgen",
@@ -5133,7 +5323,62 @@ dependencies = [
  "snow",
  "socket2 0.5.7",
  "static_assertions",
- "str0m",
+ "str0m 0.2.0",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "trust-dns-resolver 0.23.2",
+ "uint",
+ "unsigned-varint",
+ "url",
+ "webpki",
+ "x25519-dalek 2.0.1",
+ "x509-parser 0.15.1",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
+name = "litep2p"
+version = "0.4.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f680216510836ee5211c91d80add8d1b5ba2628a61b6d17263e6539e577a2cab"
+dependencies = [
+ "async-trait",
+ "bs58 0.4.0",
+ "bytes",
+ "cid 0.10.1",
+ "ed25519-dalek 1.0.1",
+ "futures",
+ "futures-timer",
+ "hex-literal",
+ "indexmap 2.2.6",
+ "libc",
+ "mockall",
+ "multiaddr",
+ "multihash 0.17.0",
+ "network-interface",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "quinn",
+ "rand 0.8.5",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "serde",
+ "sha2 0.10.8",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.7",
+ "static_assertions",
+ "str0m 0.4.1",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5193,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
+checksum = "d6eab492fe7f8651add23237ea56dbf11b3c4ff762ab83d40a47f11433421f91"
 dependencies = [
  "libc",
  "lz4-sys",
@@ -5203,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
  "libc",
@@ -5229,7 +5474,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5243,7 +5488,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5254,7 +5499,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5265,7 +5510,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5310,9 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -5357,20 +5602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
-]
-
-[[package]]
-name = "merkleized-metadata"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
-dependencies = [
- "array-bytes 6.2.3",
- "blake3",
- "frame-metadata",
- "parity-scale-codec",
- "scale-decode",
- "scale-info",
 ]
 
 [[package]]
@@ -5438,7 +5669,7 @@ dependencies = [
  "hashlink",
  "lioness",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -5449,38 +5680,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686cce3698548808445b0bbc8348a30cafc7d6fc6dbf8df0ef5027b08e4fe037"
+checksum = "663618e90cf942896a983beeec6bd1c4b25f30cabc1a54d16627866611dd7088"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70db3d6f4fdfd688a4f995f5eb3ee9764b766a01f4a4789fa5469a02d213ee12"
+checksum = "63ae3285ed10596e5d6c0f7ac651fae1dd04155ee874e55311c6885fa8435ecd"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -5551,7 +5782,7 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.0",
+ "multihash-derive 0.8.1",
  "sha2 0.10.8",
  "sha3",
  "unsigned-varint",
@@ -5568,7 +5799,7 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.0",
+ "multihash-derive 0.8.1",
  "sha2 0.10.8",
  "sha3",
  "unsigned-varint",
@@ -5606,16 +5837,16 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
+checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 1.1.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -5631,16 +5862,16 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive-impl"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38685e08adb338659871ecfc6ee47ba9b22dcc8abcf6975d379cc49145c3040"
+checksum = "3958713ce794e12f7c6326fac9aa274c68d74c4881dd37b3e2662b8a2046bb19"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.66",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -5648,6 +5879,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "multistream-select"
@@ -5665,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea4908d4f23254adda3daa60ffef0f1ac7b8c3e9a864cf3cc154b251908a2ef"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -5796,12 +6033,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -5838,6 +6076,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nonzero_ext"
@@ -5932,7 +6176,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -5953,6 +6197,15 @@ name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -6007,7 +6260,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6018,9 +6271,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.0+3.3.0"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
@@ -6067,7 +6320,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1344346d5af32c95bbddea91b18a88cc83eac394192d20ef2fc4c40a74332355"
 dependencies = [
- "expander 2.1.0",
+ "expander",
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "petgraph",
@@ -6094,170 +6347,170 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00878f866191e08a7f6a74a0378c1d4d759e356d5fc3e3dae51fa414b44fad93"
+checksum = "f7428d88b215ade92402d6c01ad02f51b6bba02c69fab8c174e0b223b335d773"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2908c5abe694fc6d1e9f1dbc9049910cf7086416e0c3214ff4734f02c055d82"
+checksum = "52ebd9fbc2bdd0015bc015103a596035de2b41d01f339f7fe732885fbd774ba0"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdecfbbcc55a4050a91bf2180b5b574fe3e20a925c1a836187041974c6f9248"
+checksum = "428dad50f10165a0d9757443733e38c94f371578fe44c9c989457d2cd61080ed"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
+ "pallet-transaction-payment 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bb2544de653caa76f88156c53ccdea218737ae00ef37b949786bc4c13719f8"
+checksum = "5ce4a9e4704ec26889ed2245064d389251a04314c144239c08c9340ea5e14d1e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d39e0cf359277a802199f4f78604ddb62f6616e6c625a3b958abec063b1a66f"
+checksum = "387cfc84d2d716e23948f9777f97cf1c57461d33b22dcceeeb03493b3ad1059b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35807c44d2caf67038ae3b3cd948a36014a63e75f96bab3754350deec7cf8e20"
+checksum = "2d9b476d5331907127d707a184f5454c8ded644c1530115241a576c578ecdfea"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-authority-discovery",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c6fadb06cb9f04998aebabf282e15a6bc35ac36de0c6fccb43a0efb38a755c"
+checksum = "ccd3d28c92dff65f0d198e88e3689f5282903138102bff84cc3794a1426665fc"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e8bc4e03c6e92cfbac89e9b505ff43fae538915fc277f4597733775c49fa76"
+checksum = "43127ee85b3a00650557a269efe1409f192df52e01abbed18dbaee9b5ccc174d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235a798b0ef83ef012fe79ed01617d84882e682aa40b937ca22e23ee429ab2d7"
+checksum = "597db43f545daa97771c2c84f8d53e7b6596a37f58fe28329b221cfc45cb7575"
 dependencies = [
- "aquamarine 0.5.0",
+ "aquamarine",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -6269,24 +6522,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c00a7041511735547ac443a14ecb2915976725dfbf1d3d9f64df20359e483e"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-balances"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bd03d979e84ec22862e62bece760601c10cc72712aa1fc43358ae9837dc9fd"
+dependencies = [
+ "docify",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a846fddc17ec4bb5901f446a1f474090de2778c215aea9ab209631c88cf879"
+checksum = "ef1a8f4f497878782988bdd7df0a825b4757921804fb7bafcc8df3b9e990c7a0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6294,22 +6564,22 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59f46e15d62db39a20fb254324f5a33cf3c652ca6aa656ba6419ae5c8059336"
+checksum = "c3e144caa40bc9a8b2947a0de2cb5eae3e701790bf9c2105536b6943d234aa7e"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6317,110 +6587,110 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus-beefy",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56765a826bcdc19693fc327757108d79ac03e7545bc3561a2434bb0238679ee6"
+checksum = "a8f1b72d43025037e2ef80598ddd2a7d2d7af7e592173fa49d787b405a314c24"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e06a681df643f0bf7225c09b4d33ceaaebfe6ebfb13d0ea686f11d20901e9b"
+checksum = "1dbfcca449d6ab4c922c4ea78647f0f9d0df0ddc29e23e2bf6c51bfd86abd97f"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813290bcfde2e10ad4a37763642e22186e28cf7d675cbf525f2276151444008c"
+checksum = "f05475c4590ac456090c430d5f8b0a3b66820048bd3b25fb273a992ea8c8e36e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8c0293db4d8d6632330e8ea1d8ad83711c144fe8b03a14ae15fe1678c7291b"
+checksum = "191fe5efd59d6e68d36b15e5abf86a7169a3c1754e2a55f0ecd0555e8326eb05"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-session",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f5bea608ae6d9e8e12cd1e57d4781ccccf62a87e498bb6318ffe2243815ab4"
+checksum = "e5669703e0437057c1054e73c10f8f2e256850905e318b0c235a587cbd89d616"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
@@ -6432,12 +6702,12 @@ checksum = "8117764e8436e9ad3f134c313a65b0dad95f1353349ddd9a78a6b527dbbeb320"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances",
+ "pallet-balances 34.0.0",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
@@ -6447,13 +6717,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 12.0.0",
+ "staging-xcm-builder 12.0.0",
  "wasm-instrument",
  "wasmi",
 ]
@@ -6466,7 +6736,7 @@ checksum = "de0cb1d904c58964cf5015adc7683fb9467b8b7e8f281619aae403f43dc2c48c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6484,377 +6754,377 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b8fc61dec0ae9760f00fb84a621e383ebb0bd1d2f6a4777bc55977624da5d1"
+checksum = "c19d08a0f7f23bb70998456f04f0234548f6ee10507b0f7e74bf067e3eeeee2b"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb285cd2c58b49219c9980b9c30d4c241920c5a55ae5df44c6e3649dd5057fd"
+checksum = "731fc36423b38b08b12dd3a3aeeaa1dda61a3207ee5ce24a209d964aede8a367"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d7050267a6ce48b2d5530ea5c3b939c8f8a70e42b26db96cb1e859a3dd40c9"
+checksum = "4cbfdd85dd5d5979067a47d4148f529da937ee017a846e98d4778764b3acfe43"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cea3c30507dd5bc3ca2657a2b729dbb9c77f0ae7103778e148d4667d1f0dfe6"
+checksum = "ef65188f4db678f5b5098d74f67e35ea5a1c2eac3c57e628e8371bf013e5f7ff"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-system",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4482e691c61ea7d68d09a0d3221a2223b36118874c1923a3733a0ff1a9d4a65"
+checksum = "2306b2b9115109232e590604edc35395b33fbf7413a84bfdb24ae0e0b9e3585d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3413d41515d5679fa680f96ceac185ede18ac22002837216c9fab863d4a367b7"
+checksum = "202d0ffa99727097251e049039fc40a4bfba7f32d0f1c831614cc94f95d430bc"
 dependencies = [
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63024f2e3aee907a345db4993982b0a853cc330e487d0b7aa2b63bf956bb2a04"
+checksum = "176f4dacb8f2e4f7cc807df18ced790d928c736b761b0eac5a855e9052efde40"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b59201c3a7fad2acc3623e0e933359588e86ba6445ec4e2ced9a56cbc150658"
+checksum = "435fb7144dd4809744d6ed5bdb96da650f59456ee95eac886e8b63ce2288f041"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859266edee477b8d7c8f07bbe48956f2d0093b7a7466b473df66e6de4dd59445"
+checksum = "cb18daba67af89afab884392286b22c9da983d63adc2b4f42be42330fb645da8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81babd3f9b3af66f27f7af6dfdea1943d16598630c5f4eda34ec56bdb7185dbd"
+checksum = "4a5474e1fe28673aa229805fa59bda1b5211a6cd5acd44d1ce8594761c5aa6a3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d72c43d36e246e388b911ce85176962eeaf7893acb472fe1c4377c7007f886d"
+checksum = "958dd8feceeeacd1ae268eb0c2133887aea5f9883ae3410712f7b483b265c145"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cf3baf644a42f0520f030e91e24c72e3d6691f7abc347345219b2e744fc835"
+checksum = "0f00efb1a89581346901a13f60c6d5be640dbfee516342f0b6b1ee679ed20354"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f6cdaa2b8423f910e260b93065b8c63c7ebbc21c288419bc7a9aa0ed7a14fa"
+checksum = "359e1e6b63a3fdd57724c35b428c5cb13d2203108f643beb5870e72d0173af5c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4957a1571ca0a761520942623d7d1ff71f2831edfc2f2fc43ad454682e50ad95"
+checksum = "98b5d37656066f03706dd9edf472785b531bb9dedec7d2a9c147cce2d4f30061"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9317c665f1692637b3ede02fef4153ae3c4a4fb4b196bbea07a6a011546ab74"
+checksum = "55e4b82d3d48d0b0828acac780b2a383f1bb4fe2b33d945850d735571f8f0398"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1edc38d7ba687163bdf2562b1fd8d440d63648c193b6c9e899ea12a607747ed"
+checksum = "d9e13bbfb772e3530e4adb0ed000d5851c89c1e21949f199196d5aed4573d6c1"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd63c332aa3c111d10268c29aa439180d4b94c8adecbf526f0a04aeea46bea1"
+checksum = "ef69c75bf20f34c61d8fa9e2eaac7e0196662c1f837193b980dd81ce8bf64b7f"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-runtime-interface",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3980bcda50ec619f93dbb8b73f824413ee5dccabe3511fca4454c49857c1483"
+checksum = "436388be290be799b0eaebb3bf0faa71029d8326fa5726c578302cb1e8f78032"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d02ba6a9a9c27685404f979534ab254f0cda028857ebdb19f7cb9aa0f52bc6b"
+checksum = "bd8a7f971f79e0ced152437e2e2c3aa3d3230c347cb7042dac81bbf58518751e"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8b5190c4421f6550504bd1753f82492c28cda5b1ccb6c2759494cdfa431207"
+checksum = "87737faadaca16055217d7d4cace15fa47690a74e077ca3ca2269ac9d63928f5"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -6862,236 +7132,236 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-parameters"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8bc500ff1d3292950a7d1b50b0e26f7cd9f886cd4a577883267d36a1da1361"
+checksum = "a61797dcd19a4bc6367b031df02209182d410c00ce08a7d1d2d4ec00be54af4c"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20718f6531ad2adf84ed0b1f845f29e29987b7fd1ccb738134c60e77177f1d0"
+checksum = "29c464ba4684a0349c0266a50bb43b281cbed79ef2a217872796c433d293fa15"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73160cf5aa5ebf1f07eb1134328b272ab16070028c8c1ee9f800ffa3a5c03db"
+checksum = "b4e06086ea1c118f1603cba84c44a986b8132f54c51a710f72e0b4c9773bc3b5"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082ef6517f3901106bc642a7bb35b9c8345cbe55c5c60dbf6b09081b2e3c5695"
+checksum = "6daeb4ce9471d306aab7a7f9b356643eb646df0be6306e241e499be442fe44da"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06afe44a0484ad3c8b943c555fe4d7ccc9da3b3cd1093ddb6a8984bae6f130f4"
+checksum = "f925341a47c6c95f02e30af26d478014d8b6885193169e5ce0869b75eb5b05d8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6c4f5bc65be570a065907239d3215036d3e29edbd0ea5c6cd01246e2ba3959"
+checksum = "3a971ac06fcaa8b0e895c881e879e3c333f77bd79d1480fdffcc5b6e74750181"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4b63ec79ab485d54cf79fd5ef574bb7f8f4e094e4a7d11b012a820d4324b62"
+checksum = "84013a3fa1fb5553c840fc0b6d165448e0765b39ef7197b1ddf8b22f367b2f37"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7570e307118a4663dd3a1d1c949f84a169ef932666e69f7fcf4357781c8c1a4e"
+checksum = "9373a0c1386cf48e6e5f0e123fe67cc933e72e32d8fb05457ee7a48a96d53bef"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925f793adb1d53c05233ffd2644ca37890d56c9716475108b975969a445d10b3"
+checksum = "9170fef289c193773d94e2b6c799f09c97b199464902a8d220bfcd399a65d726"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
- "sp-state-machine",
+ "sp-staking 32.0.0",
+ "sp-state-machine 0.41.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca61297e13c15fef1e4d3b7f2884e70c772be3a9448977ba23954e2c4bcea4bd"
+checksum = "ea68db2e88494745b73e4e774326f7d39e0dbdf35f8b79e70d134f2d99fd0ecb"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8584534df25227dd43d80803ea1978af55bf70aad5aa57c83dc3de883b1f1c73"
+checksum = "e945ae7db25c0fa77c65882fb7138ce88a28fe08f151a539ea51a115b9595137"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
- "rand_chacha 0.2.2",
+ "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68e48f3d79e0cbb9462eacc0c85c80003924124a893465047f159278338036d"
+checksum = "a563877abd32f7f3885d6437c196ba9adf1cfbc430afcc4059e6ede7ff354f38"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha 0.2.2",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 36.0.0",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
@@ -7104,7 +7374,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7119,66 +7389,66 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431ab74db8258b39fe829fb7345d38064ef7fb1ce2014b074f586303d7dee67"
+checksum = "dc26b2f096e83fd919d8d6bb586963f2374b513a7c17fe356e67f585c88943b8"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 32.0.0",
+ "sp-staking 32.0.0",
 ]
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db0ce6ccf9e1d2fe2d0b26cecce995e4b095b31bbf9f0492024fbfd4924961a"
+checksum = "204af00c1b72938db6a2d05b2dc6d1576f5957a9a9ec022ea6b5003f400f337c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ee43e8bb38a50a234ef49198413483562e229ca20d8e9d9f78b756244f6d7c"
+checksum = "edc1377f434c84a4afc3888dee27a01a0720c3fe77486f9dfb2e7310e6ad6b0b"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5982a7cc371e2b9be504465bb6e47bc27dba0b98ee9794d7fc797c24244fb6d9"
+checksum = "7b43a57df90499460bf6645fd19390c8ae85bb225566c40e36cc8e2f4663b3f6"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -7186,21 +7456,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e0d02dcd034cb57cb25f1301c6e6c43b8191b96b049e7d013564aaf5d3c6af"
+checksum = "8d451009c9a104acedb2b93aeb31096f93cfa4f39873f4b5a01d36bb3735c299"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
@@ -7210,159 +7480,176 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad5b92a96c4e38c7917477a1e5f2916c64f667f2734b2bf790ce552ceada82c"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-transaction-payment"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373788faa2053bb2f6441921599ea06de81cdff0f96fcd1e6a2e021aa1296f72"
+dependencies = [
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ba896951ef39011e27d0a91b565520636f926f01b1c912a411146af079ef5e"
+checksum = "c1019cbb539e864eabafc9cb327799c64ba885825cff822c654e4f394da1250e"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f274055d2c61888689889d6e9b9266b163e1ed298967b55bf961db26b11a60fe"
+checksum = "5d5362418d8a4ec0bf93773d79f5fc88d6533c5bb9939e495db7072d8db4dc1d"
 dependencies = [
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a11166748c80a432c52d5cc99c2b0e1d2b88592e0ad71eec7cb9f360e375c7"
+checksum = "3b88e19f21e3ddec95df10b3f9411c801733f2e0a8185a7ed18ef17e98951fa2"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1c70a4abf287304214b16d9eb88f13c991bd696f9e5318fc68e74df9802037"
+checksum = "4eb9f2e5a8595de607cfb062e0c115fadce3034c902b843f8f41636376a08d0a"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5b229675f299af7aa40749c579570dce4ab19739779a45f5a87da118af8ef"
+checksum = "8205beed2e075ef3d3651bb806d39fda894861e8e82807e42553d499d5e552f6"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249172db9f2b014a6e9d4b5c6d663bcbcb0055c1c2c7564e7bd0488ecb1f15b8"
+checksum = "ebeaf4774a0c69823a35560daea3642b98a5fc12432ce92efc0dd22b491e2dc7"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9e654cf90682370fe20a04904cb02df993c3b0dcfad861abcf2811f4fa6085"
+checksum = "ef5697c6ac29c8dd2e96d895ba6fe64b969fdcc5a5ab8cf6fa83240a519b2460"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
  "xcm-fee-payment-runtime-api",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b7038af027fcce5ba3d2f99b941fb997a5556f1fa0b8a7e7e23a448be1bb85"
+checksum = "48a95a496f4c2ce2c7b9318584f7e7c589efe456be161ad373144d8e356be6ac"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
 ]
 
 [[package]]
@@ -7380,7 +7667,8 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "frame-benchmarking",
+ "docify",
+ "frame-benchmarking 34.0.0",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7408,16 +7696,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "sp-timestamp",
- "staging-xcm",
+ "staging-xcm 13.0.1",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -7437,11 +7725,10 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7449,56 +7736,56 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
+ "sp-core 33.0.1",
+ "sp-genesis-builder 0.13.0",
+ "sp-inherents 32.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 35.0.0",
  "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "parachains-common"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd23527a3471b1c596b809591edf78d6113bba172fff4a96412d560dfea59"
+checksum = "d4a8836c0b86d76631b19fcc5daeb93c028c947a872fba0b1cd9621c0cf031be"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7506,13 +7793,13 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-consensus-aura",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "staging-parachain-info",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-executor 13.0.0",
  "substrate-wasm-builder",
 ]
 
@@ -7543,7 +7830,7 @@ dependencies = [
  "log",
  "lz4",
  "memmap2 0.5.10",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "siphasher",
  "snap",
@@ -7608,9 +7895,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.10",
@@ -7638,7 +7925,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -7728,7 +8015,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7769,7 +8056,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7792,9 +8079,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
+checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
 dependencies = [
  "atomic-waker",
  "fastrand 2.1.0",
@@ -7825,14 +8112,14 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3910a07cda88fd7e19c053f2fdfdb3296c8d55c033a71a642e531faa6029b9d2"
+checksum = "8e286afe25b8f3cb10a0e31ad71ae9816b6357887ac88d4c1c80c275c775f6f9"
 dependencies = [
  "bitvec",
  "futures",
  "futures-timer",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -7846,9 +8133,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af6a6893b41ec4eae652ca62537694c9fac71f261bec4e8e26ab6ffc21faf78"
+checksum = "cbdfe06f87b9bff2586e079f33980115ad4d98fe984220340e8463b257efc47e"
 dependencies = [
  "always-assert",
  "futures",
@@ -7863,9 +8150,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67b7867d8ddc0fe39a462dd6fafaf545be013e0a1c404cbd9a8de802ce6df82"
+checksum = "c3abdb4827ede5b83e8eb196589d14e55ba004fd039bb37270c53ca4988d6876"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7879,17 +8166,17 @@ dependencies = [
  "polkadot-primitives",
  "rand 0.8.5",
  "schnellru",
- "sp-core",
- "sp-keystore",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2547ed0976533c8ed1247187dde1663fdbe5ab366efaae80085bb4b8b410e21"
+checksum = "42cf9cefe5cd848bc70094e4ccced9a080d8e416eafbfb8347c7d04477263668"
 dependencies = [
  "async-trait",
  "fatality",
@@ -7910,10 +8197,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-cli"
-version = "12.0.0"
+name = "polkadot-ckb-merkle-mountain-range"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce323170edf8a3bb2cb6c2499642e44b8d0dccd60b3b20f9e2b9d776d53302e9"
+checksum = "a4b44320e5f7ce2c18227537a3032ae5b2c476a7e8eddba45333e1011fc31b92"
+dependencies = [
+ "cfg-if",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "polkadot-cli"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f8ad5726f1934ed4b20608ff9839cf0c4c99403b0b661376c99c06a2156737"
 dependencies = [
  "cfg-if",
  "clap",
@@ -7929,20 +8226,20 @@ dependencies = [
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
- "sp-core",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "substrate-build-script-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87729af58fda6bccdcf0258d6657ed9150a7f1fc31b3f22fa22dbdd57e1f4f59"
+checksum = "adc243c5ec6656333c0a2e8e218bea936b4d8d7566902c9825539e8058e29d77"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7953,9 +8250,9 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -7969,16 +8266,29 @@ checksum = "ef3c192d31bad69f561437549b3619a6cf02eae51d7f331efef7cfc6a56d61c2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed6798f76290be654149afd585cfef09bf796990b68c79d7ee5e5110a04d15"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67943660c3f3b0ee6f05b42c0efbf1db282f5da18552a44769d3578209c5eba"
+checksum = "c8948a0740287f37c431c0d1741f9548ea20e2be2e8ddca00221d463a1ea0de9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7994,32 +8304,32 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
- "sp-keystore",
+ "sp-application-crypto 36.0.0",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec005dad44aeca9a315e182039a7c28d08fb57822073685dd1a0bb7827993fcb"
+checksum = "87e898aa343f565e65b48c99e30ab776a2bdcc7088b048942c09594f3e3776e4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
- "sp-core",
- "sp-trie",
+ "sp-core 33.0.1",
+ "sp-trie 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eb9555f3801a69e01c9559327b65e9b8e2532f45d739648e398bba52fbe50f"
+checksum = "824bf17499380d6038106160125c14977f771e5889f85bee74183c6cb76be30a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8031,18 +8341,18 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5be1ffa029e0c3eddb50041a13c9ff3d66554effb63aaf78c61c2b10baf9b1c"
+checksum = "b415a638142f6d0a1e2adee0928fa0ec6a3a195dce4b90e2fd8985fcd11629ca"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8050,7 +8360,7 @@ dependencies = [
  "fatality",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -8064,9 +8374,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efbc62e46127f70a0502dfe5c3f058166425e62c67227028f87a4fb908ba06e"
+checksum = "ab2b311707daf7f3183c62fc1c7758be4ae566b5a4d9320dbefe938d31a0831a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8075,7 +8385,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-maybe-compressed-blob",
  "thiserror",
  "tracing-gum",
@@ -8083,15 +8393,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fc22bda776143d65bece22258364fa84d813164b742bc228877fa8871a1329"
+checksum = "2db9fcf15099e8ecd8e23f636302d137d73dba14236e959fb4ab091cfec3ead4"
 dependencies = [
  "bitvec",
  "derive_more",
  "futures",
  "futures-timer",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "kvdb",
  "merlin",
  "parity-scale-codec",
@@ -8107,19 +8417,19 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52df6f52e1e4a87b52c98b191cf37f14bf0c85fb73c792a10d86d4c9884170ed"
+checksum = "eea8680f339aecffaf2238a5f8e1bc9689cf5d67b7071760707aedfc4eaa3160"
 dependencies = [
  "bitvec",
  "futures",
@@ -8140,9 +8450,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8785e8abeef80825f48f581b34386ec92e4d4edb78256836a5723f7c2a33003d"
+checksum = "efd7fb51c8affa18d0f5db31b682678d501451584c5ceddf686bad9dffc5950f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8154,22 +8464,22 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5855878573327e0975457dfea64b94081254ccd27ed32db19e2c3e9c11da832"
+checksum = "5081cfead44128c0a6628d99437c19f649bc55f8dd2ed59c09874d7622b2d198"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
  "wasm-timer",
@@ -8177,9 +8487,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bef20a6df020d75b2750ac2b7926e17305588508f2ecafcf486f104145b337"
+checksum = "81220717085bd60549c8c5e4adfc4bea56e224f825f03f8660b953bab79fd1b0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8191,7 +8501,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -8199,9 +8509,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f0c8062fd9dcae3ca07ef32881e796979d7171187de3cecddc128bb03740fd"
+checksum = "417bc195bb50f5c1b5db5d8d04783b81e8e54e9c82447d9880f58a59670f8db2"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8214,9 +8524,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d6f7ea52ddafcc80371a6e619e7c2247f1e2373b97180397ff832bd5a49d89"
+checksum = "c9373236b5d0b50c506204f456e32c13a1fda71a0f02ba6b6228c1fe07812e0d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8232,9 +8542,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb9022aa49a3cfaf5c452dcfb41f13511599409e569be527b229c3a94311b1f"
+checksum = "a854e6e2d8b5570ac2ec3af9f0b39fff70082c7b26df4621460a3f563c06f2a6"
 dependencies = [
  "fatality",
  "futures",
@@ -8252,9 +8562,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651b0dcf8d948b80c1980ccd973a7e3d666f30c74762a4f2b3b2312754936337"
+checksum = "4546a35725c881bae40b125237c72fa3ba9398bd7d59cdfc594d018a3d86cfb6"
 dependencies = [
  "async-trait",
  "futures",
@@ -8263,16 +8573,16 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 32.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e908f038f83eb28bf1ed586bb3bafb59907d1aebe0ae5ebdb4892a88eee1982b"
+checksum = "2d1bb5aa18ecf4e7102b0aca1bf5992ca09b18969c5582852ed81d088a5535dc"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8288,9 +8598,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd8237ae0bba201d668f24aa574ffdebcc4af6ed265aa924b2ff99680a04eb7"
+checksum = "0b087b67faa4ad089f1979fe1a510afe856a9c5a356c78c9f02ba3def02d1d51"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8307,28 +8617,28 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5987cd5501271b74a95664ee7f5ad1bd8e96c95b8c8bb7ca843b264ef5b086b5"
+checksum = "08225e89f86d7ac77a58e75e2f42f25487575717673d940570dc02b28423047a"
 dependencies = [
  "always-assert",
- "array-bytes 6.2.3",
+ "array-bytes",
  "blake3",
  "cfg-if",
  "futures",
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 13.0.0",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "rand 0.8.5",
  "slotmap",
- "sp-core",
+ "sp-core 33.0.1",
  "tempfile",
  "thiserror",
  "tokio",
@@ -8337,9 +8647,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacfc74431199c07b35dcf1710fc800d158cb28bcc2e896d0dc2fa696cf08254"
+checksum = "38b4d5b001b0e079ec3043103543d52a6c561ea58afd7e4a552c2b5f82219d99"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8347,33 +8657,33 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f5c0302abddbd120abfab4cf9de2794ac2aed3554d2741b0dfa79962595b22"
+checksum = "da16a57610c19669a557bfbad8619dde57d72392b6ee77ceeae15f6b6e6bc327"
 dependencies = [
  "cpu-time",
  "futures",
  "landlock",
  "libc",
- "nix 0.27.1",
+ "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
  "sc-executor-wasmtime",
  "seccompiler",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io",
+ "sp-io 36.0.0",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8381,9 +8691,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581aab355ba6d81e05753f8fa401c928ddcda8d553dec4450abbc330956525fa"
+checksum = "bb515d39f8fd15b6ea0377feb6c891fe76edcc4845958e1ae0595ae5b4239db2"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8397,29 +8707,29 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622b0231ea2b17096a69dcfb1a62ecb64ca3fcd91830efed0bf25c6b311c1eb8"
+checksum = "ff7a596644f8861f8a298ca06bd489abb359a42dc4314bd7b9cc9bf8c53f066e"
 dependencies = [
  "lazy_static",
  "log",
  "mick-jaeger",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
- "sc-network-types",
- "sp-core",
+ "sc-network-types 0.11.0",
+ "sp-core 33.0.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc571e16a460fb03319a17d037facb4924f549810e1fcacefbebc2c4cd2e3ee"
+checksum = "7b758d586de1b1fb1a83d008be8f1930b131cf3b6959f9a1d24021a2906b9e9b"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -8437,9 +8747,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2761c570ac12f5dc48534cc39512118ecbfeb04116fdff5c4c79cf85263a1ab3"
+checksum = "6da2f608ea60ec601aa33863637de01f325235eaaa0c6193eee9aea27755b5a9"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8455,8 +8765,8 @@ dependencies = [
  "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
- "sc-network-types",
- "sp-runtime",
+ "sc-network-types 0.11.0",
+ "sp-runtime 37.0.0",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8464,33 +8774,33 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e862d29bcc6b6d76ea41a08627edddb1f1fa071821019462f07e3bf53801336"
+checksum = "39956470139586e4b10b9e913dc7ae26005a45ba1c4e98feade1d9449e4a25ed"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab90aceb1e00cb2eff617785f4bc8a40501f525359fb718d2c9ea5b90427d66"
+checksum = "8a560c09498c1b311e96896e6ed952308d2972577035ac643ed57d070956877b"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8499,9 +8809,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2973a2b608b792adc4a042f9d06d4eebfd63a05557c35bdd5040f445e26a680"
+checksum = "7f94a624078ec1714b468f57dbc1c8730ec24a4f3241d774c43b5c501b61ed66"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8515,34 +8825,34 @@ dependencies = [
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30298b2d686e24684754a5236fb8986c7c1777f8695ee81c61f5c69a891ef36"
+checksum = "14e7920f7ae2e610b615ecd764c43c356f38492cc3236520e83537cc9e21141f"
 dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
  "futures",
  "futures-channel",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "kvdb",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
@@ -8556,32 +8866,32 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-overseer"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b0505f383fb8d474cef23cc1a8e24617cd9fd17ee44bbd13f5f92f98de53d9"
+checksum = "95b741afa899f746735fe67e62cbfebc5168b95bcfbaad75f27b01a6e6a5ff8a"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "orchestra",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
@@ -8595,48 +8905,66 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 12.0.0",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-parachain-primitives"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cbf31ea1fbf6e8f2db854813269abfca3a7eb5e2c4b1493345a29b2a01abd5"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "parity-scale-codec",
+ "polkadot-core-primitives 13.0.0",
+ "scale-info",
+ "serde",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae78f3443b86249d5f7756177984d6b3c6b1af9432ff2a48e299be2c6ab97297"
+checksum = "a7621b5ba096c04bf81c9e310c6cb327c365de5a68993aea380a1a897f3b0836"
 dependencies = [
  "bitvec",
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 13.0.0",
+ "polkadot-parachain-primitives 12.0.0",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b791f93e89c38bafc894e9364c27a85b8d5696a9280f95f22c39a601cae4e6c8"
+checksum = "c867202b559a9328f8f314d289a5e326f903a758e6b00e1fc1f7d60cf2941115"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8655,35 +8983,35 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3effc5cafb231ede1c394abce9575c292e95170e11ee1ecc5644d25cf35b54b9"
+checksum = "1215fb26c995f9a2ac815c28498e90347373d868f9e07bb8f180ea607a678108"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -8692,7 +9020,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -8703,29 +9031,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfaa021e4639e9fcba7c40111d93720b82cea98d667889760e46a40137e3d47"
+checksum = "d54a84f56cf84685008ef66eb85d7ce6d87511b9c21a38ab214bbdd2917ae93f"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-std",
@@ -8734,22 +9062,22 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9f30223690133e9fbede03615c6b88aeaa774f777067d2253057ef35ba0270"
+checksum = "69158a812736547a76333b97da33fdcc2830e6f8c613d8e89541845e294537a6"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -8757,8 +9085,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 13.0.0",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand 0.8.5",
@@ -8766,34 +9094,34 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 13.0.1",
+ "staging-xcm-executor 13.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6acbf05debbbab4831318fdbe0619742573dda47721af7e2ff042def2ec77a"
+checksum = "1cd7113642afd582260667a50d550378310fb68be3991316eda3ab3c82a37ccc"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -8804,17 +9132,17 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "polkadot-approval-distribution",
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 13.0.0",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -8839,7 +9167,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
@@ -8872,7 +9200,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -8880,22 +9208,22 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
  "sp-keyring",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.41.0",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 35.0.0",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 13.0.1",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
@@ -8905,9 +9233,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1a7eff92a348821650ed63e02c28a7ee2b5a76ef12d8289882a1e6f2e7de90"
+checksum = "246d41a17db83e3dce3d0b451887fb22991aceda9c78fe092f54fa98b6296178"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -8921,21 +9249,21 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore",
- "sp-staking",
+ "sp-keystore 0.39.0",
+ "sp-staking 32.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b879ec2b27bde2a05b70bd4826d7785c1e01ef72fc4a058d1055b1c95f8deb6"
+checksum = "9b9b54c9dbd043cdf485a5e0c2718892fe5c64e6114e2d1ce578fb33605b7c2e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-core",
+ "sp-core 33.0.1",
  "tracing-gum",
 ]
 
@@ -8988,7 +9316,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -8998,7 +9326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9040,13 +9368,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite 0.2.14",
  "rustix 0.38.34",
  "tracing",
@@ -9125,20 +9453,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettier-please"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
-dependencies = [
- "proc-macro2",
- "syn 2.0.65",
-]
-
-[[package]]
 name = "prettyplease"
-version = "0.1.11"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28f53e8b192565862cf99343194579a022eb9c7dd3a8d03134734803c7b3125"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -9151,7 +9469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9185,12 +9503,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "thiserror",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -9234,14 +9561,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -9256,7 +9583,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "thiserror",
 ]
 
@@ -9268,7 +9595,7 @@ checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "prometheus-client-derive-encode",
 ]
 
@@ -9280,7 +9607,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9314,15 +9641,36 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph",
- "prettyplease 0.1.11",
+ "prettyplease 0.1.25",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.12.1",
+ "log",
+ "multimap 0.10.0",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.20",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.66",
+ "tempfile",
 ]
 
 [[package]]
@@ -9348,7 +9696,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9358,6 +9706,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -9644,9 +10001,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -9691,7 +10048,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -9721,14 +10078,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -9742,13 +10099,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -9759,9 +10116,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "resolv-conf"
@@ -9834,16 +10191,16 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224e7b002c0ba04bcee4bf25e2d90ff1895a9c1171fd8c3162c63a558c33a0d4"
+checksum = "5f09353883a98e00d2d8e1e834afa8f8d4fe56f00179843c9b88226db38577ef"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -9853,7 +10210,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -9886,7 +10243,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -9895,7 +10252,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -9905,29 +10262,29 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-genesis-builder 0.13.0",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "sp-version 35.0.0",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-fee-payment-runtime-api",
@@ -9935,19 +10292,19 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578bde81aeca421df7d898726f0d3d9caea11eed87d77760be71177ce071977f"
+checksum = "f07e4b8066110a58d9e6290b5f5ff189684495a0ae8c4b07eca5f5b8d1353595"
 dependencies = [
- "frame-support",
+ "frame-support 34.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
 ]
 
 [[package]]
@@ -10214,9 +10571,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
 dependencies = [
  "bytemuck",
 ]
@@ -10232,21 +10589,21 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e78771bbc491d4d601afbbf01f5718d6d724d0d971c8581cf5b4c62a9502f7"
+checksum = "a3f01218e73ea57916be5f08987995ac802d6f4ede4ea5ce0242e468c590e4e2"
 dependencies = [
  "log",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-wasm-interface",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4f35b9a8b91dd1232a26041c064d57b9f03ad2b80d2912512cfd1e4851e506"
+checksum = "218036a165861e60bef6f585c20fd2eb89286056320ffb67c86fd935e80bc9b6"
 dependencies = [
  "async-trait",
  "futures",
@@ -10259,26 +10616,26 @@ dependencies = [
  "multihash-codetable",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.12.6",
  "rand 0.8.5",
  "sc-client-api",
  "sc-network",
- "sc-network-types",
- "sp-api",
+ "sc-network-types 0.11.0",
+ "sp-api 32.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f71eb27c36bb0cda3e67f1e0c4c45ced6672ad4c47148da6bc7fd729e99865a"
+checksum = "ca210a343d5ad2f44846d61e43acc5aca356470f5524b72354653f7270dbf6c6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10288,38 +10645,38 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4190e69ccdf1b10c530e110345d67c6347aa0bc03fa56723103d834fb8ac907d"
+checksum = "23c1a029e5f794a859bbda434bb311660fe195106e5ec6147e460bb9dffb3baf"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3256a5e3294dc363ddb17ac3040c33b9848269dd288eaf8ac6a2972f8a1d884"
+checksum = "d5b161ea70cfb2340f8fdd288fca185a588e689cf1f07d6439e45541f4b5fe8b"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "docify",
  "log",
  "memmap2 0.9.4",
@@ -10332,12 +10689,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.13.0",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-tracing",
 ]
 
@@ -10350,21 +10707,21 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397091529b095369e8b9342a0dcb732bf6ec672b4be9db76b5174951618f541a"
+checksum = "25220d6f9120bb49255e6806586eae22c999242fcfc61c3fd797a36180661ee9"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "chrono",
  "clap",
  "fdlimit",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "libp2p-identity",
  "log",
  "names",
@@ -10385,49 +10742,49 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-keyring",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 37.0.0",
+ "sp-version 35.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec1bf37389619d861680f7da315ac5a815e5cd924ec9a0adb86e4ba4aac7c99"
+checksum = "6812c65d63c576e0f61d063fb0794420ce6312c5de9072269643ac1355537ea9"
 dependencies = [
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-database",
  "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "sp-statement-store",
  "sp-storage",
- "sp-trie",
+ "sp-trie 35.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe19e497ab77b89efa4e2b885af725d6ed59579ebe8df96b820f5b122c10da9"
+checksum = "fdf275ceb82f4a508c0553df6a0ebc8cbfc6b03fe894ab509cdc4a0aa64d5864"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10437,50 +10794,50 @@ dependencies = [
  "log",
  "parity-db",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-state-db",
  "schnellru",
  "sp-arithmetic",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0178e3ef8d317456e352466a9c5d3b6d9b5861a64b43c01ab62435e24fc68a51"
+checksum = "a8599723d670725369aca94e0bc76863c14d7a68ee1ba82d0c039359f92b200e"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "log",
  "mockall",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be48cd2fa20a6800595f7f49dbc929ad72348673c38eb7faa072cb8dfd7b47ce"
+checksum = "b312ad1c846f78dbfc1f755bd7a0cd61910214b821cf7e0aebce96d4b1b3a0b8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10491,26 +10848,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d58429c3660dfb86b9c0a1529dbc444f1ba8c8135812468497751d5b2567d6"
+checksum = "1e676a852225485d7f89ed2bd985b14d371964e3f682fb52b32b3d10dced3280"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10520,34 +10877,34 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-epochs",
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-inherents 32.0.0",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3bd3762945244a50e7e64aa9302405ba3d225a807872a4f99e8250e5ec4e60"
+checksum = "d434d7c76dee1c4b0d1594eb517c6f4b923b08b81c3ae890fee6411e70451d73"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10555,49 +10912,48 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0f27e60a0a3135c991e26883c4827f8bb3fa082ee84690544eea9040d0edf8"
+checksum = "4800134697fa5913275969e684ce709d0d73b3cb9d28824b07c4bf2e86bf204c"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fnv",
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-gossip",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-mmr-primitives",
- "sp-runtime",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10606,46 +10962,46 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db1d87a1107de282b3208e25370c1f54dcfc9f0c12bdea52fad127df4929c63"
+checksum = "9eec266bc09311db98c10dde271ceef159657d65280df6b2b69c36ef32e3c817"
 dependencies = [
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
  "sp-consensus-beefy",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d878112bf0e7b267eb753e9a43432616dc190f85be921bc03d13c42a7c21bd"
+checksum = "84678180c64ce942dd6c38faae95dafdb097b95dbc6bccb2dfb125646114432e"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba0980a68efdb28cba1a8051dd27d104258870f16287df9d576caf36add3ebc"
+checksum = "453c5b758a15d8addfd4874fa370a4dd14a4e3e5911dc663da6f384f4d8090fd"
 dependencies = [
  "ahash 0.8.11",
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -10654,7 +11010,7 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
@@ -10664,30 +11020,30 @@ dependencies = [
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c587c6b017281f2029a7901de1e2f6f85ee8b365e9d15b159a5c44450fc71f6"
+checksum = "ff06659eb842ea2b090a3dc95dd39cddaf00b670c7938f2dec94d1fc30d84c5c"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10699,16 +11055,16 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b755082e44000f02660697560c279d81cea4ea984d5a21eb27a2179c92912fbc"
+checksum = "68c923c07005b88b62c6e63b2e08c9a45ac707ef90c61ff5f7f193e548ad37af"
 dependencies = [
  "async-trait",
  "futures",
@@ -10722,41 +11078,41 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0738d2e654f8cadb8b5b5f64c281654838202bf77641656b7fe2bd5346a25b"
+checksum = "321e9431a3d5c95514b1ba775dd425efd4b18bd79dfdb6d8e397f0c96d6831e9"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-executor-common",
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
  "sp-externalities",
- "sp-io",
+ "sp-io 36.0.0",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-trie 35.0.0",
+ "sp-version 35.0.0",
  "sp-wasm-interface",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c61ef111d7ccc7697ee4788654f4f998662db057c27ca2de4b94f20e3e6ed1"
+checksum = "aad16187c613f81feab35f0d6c12c15c1d88eea0794c886b5dca3495d26746de"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10768,9 +11124,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb96b22b779ba14f449d114b63efd162f95f1cdf773cdac29f75fe6a250de24"
+checksum = "db336a08ea53b6a89972a6ad6586e664c15db2add9d1cfb508afc768de387304"
 dependencies = [
  "log",
  "polkavm",
@@ -10780,15 +11136,15 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be4652ea58937af5727433075934fe4cee90b9fac11796869caca991ddb5003"
+checksum = "1b97b324b2737447b7b208e913fef4988d5c38ecc21f57c3dd33e3f1e1e3bb08"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
@@ -10799,9 +11155,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb38b9ee63b01ed966f67789684b517cdc7891c0ac30ddac0e039695a43ab03"
+checksum = "74ddef3aa096a40f84599c90c4045ece585fcc06ef64d657fe88f8464f3d7106"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10812,31 +11168,31 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbafebe46cb7a380d6a1a77c045af06de3cf92ffcb5bbbbb1567e3b0c94d688"
+checksum = "076394555f3325fbe66d5e1216eb210c00f877910107a02d3997afbad9b23af6"
 dependencies = [
- "array-bytes 6.2.3",
- "parking_lot 0.12.2",
+ "array-bytes",
+ "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c48f0897bac630c7f58e0e8f5b5930db18641ac5c0df6fcca0335520c1be74a"
+checksum = "ea3756952a98f6e8aab2715e15d8af73191d736c1c3e35c05a7bac2033c33949"
 dependencies = [
- "array-bytes 4.2.0",
+ "array-bytes",
  "arrayvec 0.7.4",
  "blake2 0.10.6",
  "bytes",
@@ -10846,27 +11202,27 @@ dependencies = [
  "mixnet",
  "multiaddr",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-network",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus",
- "sp-core",
- "sp-keystore",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94a6131f2c50126601a01d9b60a8df569aa8483cf6754e280b754a5e716a297"
+checksum = "bcd70d3fb1d9ff0165ea9c23cb4f6963e8fe0d65847ccae3fc4c7fc92bd02543"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec",
@@ -10879,20 +11235,20 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
- "litep2p",
+ "litep2p 0.4.0-rc.1",
  "log",
  "mockall",
  "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
- "prost 0.11.9",
- "prost-build",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
  "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-utils",
  "schnellru",
  "serde",
@@ -10900,8 +11256,8 @@ dependencies = [
  "smallvec",
  "sp-arithmetic",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10914,28 +11270,28 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae304be8447d6101c7d314932137ff2405db43bc7daf4b9c0c52341bdc9265ac"
+checksum = "d3b9a2597285d5bc18b871d5bd69e99c724caffddee22b002b27e7e89a37e6a9"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "futures",
  "libp2p-identity",
  "parity-scale-codec",
- "prost-build",
+ "prost-build 0.12.6",
  "sc-consensus",
- "sc-network-types",
+ "sc-network-types 0.10.0",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5317c3a30c77978ef7cfb2655e4dae2f7ba82df1622b6b6e81c854c19ffb43"
+checksum = "962b37f9939ea0d678219cd4beae5b604b2ee2836e670c14fe3d347e21d57790"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -10945,42 +11301,42 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a2b0e0c87d74704a758be2d3119bbbf652910b3de0d3074864531f2e1afd3c"
+checksum = "b9d0c7dabde3a1a4a49b383503e4589bb3373044fc8513dbf849547f7d450af4"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-channel 1.9.0",
  "futures",
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.12.6",
  "sc-client-api",
  "sc-network",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d3a03c11fd5ed3c596a055d79596e6c0d7ea5166b627346e0381adde49dd50"
+checksum = "61620bf88ffa4e67dfcb245569c293a7a3815b9f8d37f93fa9944bddda68ee9d"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
@@ -10991,12 +11347,12 @@ dependencies = [
  "mockall",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build",
+ "prost-build 0.12.6",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
  "sc-network-common",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -11004,8 +11360,8 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11014,11 +11370,11 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8586ce7e34e555021b574ec98c4d459cc46625f1d061a3ed8bea6a400e8648"
+checksum = "dee98c3909782dc7aac343b41ea8d8d2525d4def168c005bb1fb37b4e8a4ecc1"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "futures",
  "libp2p",
  "log",
@@ -11026,10 +11382,10 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11041,7 +11397,22 @@ checksum = "a6b473a65393f65579019e4280cc116848439985c62724db8402bbfa7da462d1"
 dependencies = [
  "bs58 0.4.0",
  "libp2p-identity",
- "litep2p",
+ "litep2p 0.3.0",
+ "multiaddr",
+ "multihash 0.17.0",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-network-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78a8ca5b07ab6ac40dd21e7724453a42c186ba546406c198aa8c6f31e4e6f2d"
+dependencies = [
+ "bs58 0.5.1",
+ "libp2p-identity",
+ "litep2p 0.4.0-rc.1",
  "multiaddr",
  "multihash 0.17.0",
  "rand 0.8.5",
@@ -11050,11 +11421,11 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb6f76c65abdabfadb497a5fe33733ec67af15221aa1c72686096aed75b28b8"
+checksum = "9230e5537f553bb9dcaa5f782acf0e2de6ba7658fe5fc9b7844c0a675c69946a"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "bytes",
  "fnv",
  "futures",
@@ -11066,20 +11437,20 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
  "sp-externalities",
- "sp-keystore",
+ "sp-keystore 0.39.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "threadpool",
  "tracing",
 ]
@@ -11096,15 +11467,15 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3af3898afc9e63bfda6bbb75a20bb66a4b3de0bc077eb1b67d94b04f69b984"
+checksum = "01b626348dad6f3eeda3595dd1331dc3f04468e075d61ec53599bcb084f93b41"
 dependencies = [
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -11114,24 +11485,24 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
  "sp-statement-store",
- "sp-version",
+ "sp-version 35.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2656a0da9ce809fb31dc0517b7e0a4185001785154b59cd9546566f1db8df346"
+checksum = "6d9e316c596ddc56f452faa325e0981aa58389cbbb908f7f13aad00a71efbb15"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11141,23 +11512,25 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 37.0.0",
+ "sp-version 35.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "15.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f6d0924de213aa5c72a47c7bd0d7668531c5845e832d1ac5c33c96d0ff7b9b"
+checksum = "5afa7a60f1f6349e61764c21f644c3d4549a7a45c097123746c68e84c0fb8738"
 dependencies = [
+ "forwarded-header-value",
  "futures",
  "governor",
  "http",
  "hyper",
+ "ip_network",
  "jsonrpsee",
  "log",
  "serde_json",
@@ -11169,18 +11542,18 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f2b3d4ad7238f031c85395980f3b05026dba6f596e1e3600274fa9c30974e1"
+checksum = "98b7a2a25ae6329560d7b5b75f0af319629fd0cfbdc23663ce6aa20d439a4439"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "futures",
  "futures-util",
  "hex",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
@@ -11189,12 +11562,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 37.0.0",
+ "sp-version 35.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11202,9 +11575,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d4e550aabcfba3a9e6a2c4e23dcfef362cb62bea2cfc3348879e327482ec72"
+checksum = "8e97eceb358fc3755d5675591f707cb978b1032005e8c32bee43da88d58a7a5e"
 dependencies = [
  "async-trait",
  "directories",
@@ -11214,7 +11587,7 @@ dependencies = [
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
  "sc-chain-spec",
@@ -11229,7 +11602,7 @@ dependencies = [
  "sc-network-light",
  "sc-network-sync",
  "sc-network-transactions",
- "sc-network-types",
+ "sc-network-types 0.11.0",
  "sc-rpc",
  "sc-rpc-server",
  "sc-rpc-spec-v2",
@@ -11242,20 +11615,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-externalities",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.41.0",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 35.0.0",
+ "sp-version 35.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11267,35 +11640,35 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259ab2e8e2fa1e7a1c38dd8a88353f80e66369ef8b48d5f7098dbc18c67887f"
+checksum = "863b63626c6602167953125b7b0430939b968d6ba13bd795998ac66d3ce124c9"
 dependencies = [
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
- "sp-core",
+ "parking_lot 0.12.3",
+ "sp-core 33.0.1",
 ]
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4536eb51128eed3d3780f442ca74a4464f26401065bc4cf038609c0f9efeab9c"
+checksum = "7e69686e7593e6d90432e5476b85219cf8636f0e9941d84d30cf80b2995cc632"
 dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core",
+ "sp-core 33.0.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910d78b0ea4778a639a9d1345d4e5ce27721ed0d717635aded1bb6c522044bb2"
+checksum = "c2de2ec69614f29a2f1a8f9dd92f296a6c8990d156a6737f42744b9462311b15"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11307,15 +11680,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985818b31ecd4e04edadbf6124e2b71033551c08ff891bd9449fbddd2346ddf8"
+checksum = "5a48d1c042e09d19cb4812f5d7b76781095b8832e8ffe07b6679ee524ebbf782"
 dependencies = [
  "derive_more",
  "futures",
@@ -11327,23 +11700,23 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 36.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a874600f40a5cef2e1482574f7665ed005f7c3b7594f9abddcb2e015651c4d9"
+checksum = "d1186331805100037171f2069a3c3b4a9c8ec01144863626c3276b999960af67"
 dependencies = [
  "chrono",
  "futures",
  "libp2p",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
  "sc-network",
@@ -11356,9 +11729,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7513573600566bcc7a41153c6a99b628e800acd65bc124c3ac595322324021"
+checksum = "86cfe597106614e64cada52406df9d5e6c802c3982ef367d83ff240a0b59e7c4"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11367,21 +11740,21 @@ dependencies = [
  "libc",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "regex",
  "rustc-hash",
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log 0.1.4",
+ "tracing-log 0.2.0",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -11394,14 +11767,14 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f865b689f7f732de5c6129cbdb793d7c71a88ef0d1636d8b843e590d5d766a"
+checksum = "e7bc0d2515ec772b2391e3e641766c13d1a9b66fd60a7f68a4b82be5ae33801c"
 dependencies = [
  "async-trait",
  "futures",
@@ -11409,16 +11782,16 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "sc-client-api",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11427,9 +11800,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618532cf1e4afbc3a3f9046bfb4aaceba46fa9888ec9d1d12e9fe5448aa7ee82"
+checksum = "39dfa40c94e3965547d4fa0e7f7bc491b02bd7891cfd226a5fa8451c707f18a4"
 dependencies = [
  "async-trait",
  "futures",
@@ -11437,8 +11810,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
@@ -11453,32 +11826,9 @@ dependencies = [
  "futures-timer",
  "lazy_static",
  "log",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "prometheus",
  "sp-arithmetic",
-]
-
-[[package]]
-name = "scale-bits"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
-dependencies = [
- "parity-scale-codec",
- "scale-type-resolver",
-]
-
-[[package]]
-name = "scale-decode"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "scale-bits",
- "scale-type-resolver",
- "smallvec",
 ]
 
 [[package]]
@@ -11506,12 +11856,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "scale-type-resolver"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -11705,9 +12049,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -11723,13 +12067,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -11932,14 +12276,14 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb6f55c7308986f519ce3d554f832774e6212b14774e72313a0c1a3591adf5a"
+checksum = "12d7d232571cc6f04fee2fa2486dddc222ed2a043fbf9ad942fb7b98a87f4b2d"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
@@ -12052,7 +12396,7 @@ dependencies = [
  "log",
  "lru 0.11.1",
  "no-std-net",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -12136,15 +12480,38 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime",
+ "sp-runtime 36.0.0",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 34.0.0",
+ "sp-version 34.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84f09c4b928e814e07dede0ece91f1f6eae1bff946a0e5e4a76bed19a095f1"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro",
+ "sp-core 33.0.1",
+ "sp-externalities",
+ "sp-metadata-ir",
+ "sp-runtime 37.0.0",
+ "sp-runtime-interface",
+ "sp-state-machine 0.41.0",
+ "sp-std",
+ "sp-trie 35.0.0",
+ "sp-version 35.0.0",
  "thiserror",
 ]
 
@@ -12156,11 +12523,11 @@ checksum = "213a4bec1b18bd0750e7b81d11d8276c24f68b53cde83950b00b178ecc9ab24a"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
- "expander 2.1.0",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12172,8 +12539,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296282f718f15d4d812664415942665302a484d3495cf8d2e2ab3192b32d2c73"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-std",
 ]
 
@@ -12195,143 +12576,143 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8494eafd70194198b7fd82446da59380c7346bedf68e83dfbdb5f338395437"
+checksum = "7c06b0d26bcc9b5db298c4e270fdff286411912af51bc0d9ef7d04f139ee3146"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51cf3d8fb96de98aecdd32cdd4a735af4d84fae274314f411f95c89d4dff6ad3"
+checksum = "329e1cfb98f113d91d0db80a6e984cbb7e990f03ef599a8dc356723a47d40509"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488d3cc94c345ce55d1890239bb256f4418f9566e29b7b90f01817bc7b553a08"
+checksum = "6900a6681cfa8f817e14426e5b5daa7fb101431917182361c995e62f98ed0b09"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "schnellru",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f400a20113301fa91094c210b9b9b63f066cee55f22517768eaadf3519124d8"
+checksum = "a7effe855bb4ca3a24273d10802d6b536d618936fee9dfbcbbdae19ed1bb042e"
 dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8904da70720b26f207b6ae1d140cac4f5b10b94bce535e08ee0df08f3a27a84"
+checksum = "464c5ec1ffcf83739b8ff7c8ecffdb95766d6be0c30e324cd76b22180d3d6f11"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f99229c382c3f849160da42c897321fd6b82fe685bc0c4ba4afdd51b818bd1"
+checksum = "eec35149556b61c81c12b57ef90ff3d382a2b151f28df698e053a9f68f7aeb3e"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5eb094064dd8f1ff03bd92c843c5f979c1b18e955afb5c0ad98f9c781225e12"
+checksum = "d8f70758400b17ea3bd2788108434cc726a47a057b50acf5d095b02872e52797"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
- "sp-io",
- "sp-keystore",
+ "sp-io 36.0.0",
+ "sp-keystore 0.39.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4d90b65fd82e77c3b8c382c3a9e669bba5ccfb5402a945cde88984c98681b"
+checksum = "7deefa0a09cb191c0cb7a7aa8603414283f9aaa3a0fbc94fb68ff9a858f6fab2"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60823551c6987e2f5e1dda772140a09850e866e704757662795b8e7cacf9b228"
+checksum = "063ccdb38545602e45205e6b186e3d47508912c9b785321f907201564697f1c0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12345,7 +12726,7 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
@@ -12363,7 +12744,54 @@ dependencies = [
  "merlin",
  "parity-bip39",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types",
+ "rand 0.8.5",
+ "scale-info",
+ "schnorrkel 0.11.4",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "33.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3368e32f6fda6e20b8af51f94308d033ab70a021e87f6abbd3fed5aca942b745"
+dependencies = [
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "dyn-clonable",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
  "paste",
  "primitive-types",
  "rand 0.8.5",
@@ -12408,7 +12836,7 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12418,7 +12846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722cbecdbf5b94578137dbd07feb51e95f7de221be0c1ff4dcfe0bb4cd986929"
 dependencies = [
  "kvdb",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -12429,7 +12857,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12452,8 +12880,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 31.0.0",
+ "sp-runtime 36.0.0",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb26e3653f6a2feac2bcb2749b5fb080e4211b882cafbdba86e4304c03c72c8"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -12466,7 +12907,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 36.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6766db70e0c371d43bfbf7a8950d2cb10cff6b76c8a2c5bd1336e7566b46a0cf"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
@@ -12484,27 +12939,54 @@ dependencies = [
  "polkavm-derive",
  "rustversion",
  "secp256k1",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-keystore",
+ "sp-keystore 0.38.0",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.40.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 34.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a31ce27358b73656a09b4933f09a700019d63afa15ede966f7c9893c1d4db5"
+dependencies = [
+ "bytes",
+ "ed25519-dalek 2.1.1",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core 33.0.1",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-keystore 0.39.0",
+ "sp-runtime-interface",
+ "sp-state-machine 0.41.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie 35.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d2c495248bd141fe04ec639785c874949b2c552c00ea4afc4c183c654466ce"
+checksum = "65a24506e9e7c4d66e3b4d9c45e35009b59d3cc545481224bf1e85146d2426ec"
 dependencies = [
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "strum 0.26.2",
 ]
 
@@ -12515,8 +12997,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6c7a7abd860a5211a356cf9d5fcabf0eb37d997985e5d722b6b33dcc815528"
 dependencies = [
  "parity-scale-codec",
- "parking_lot 0.12.2",
- "sp-core",
+ "parking_lot 0.12.3",
+ "sp-core 32.0.0",
+ "sp-externalities",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a909528663a80829b95d582a20dd4c9acd6e575650dee2bcaf56f4740b305e"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 33.0.1",
  "sp-externalities",
 ]
 
@@ -12543,57 +13037,57 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2242e7a802822109e007c3d6ee79640f8dc3abee7139d34ce029c7478361be8c"
+checksum = "a1ac523987a20ae4df607dcf1b7c7728b1f7b77f016f27413203e584d22ffde3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "31.0.0"
+version = "32.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedd59967d2f759bec2be705840d170a5dbf38866acaedffe7c813e7547325bf"
+checksum = "ec4370db10d0f7b670ba33d1a69dc2a09a1734d45b3d4edea78328ff9edf5d31"
 dependencies = [
- "ckb-merkle-mountain-range",
  "log",
  "parity-scale-codec",
+ "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e52344b6fd91289a87c3fca03e5147df178167b150e1a10b82243434f43e134"
+checksum = "643b08058800b3a1bd0ad7155291e75e14c936974837c074ae3cfdc5d1fa294e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbbd2096fda34c2f6f9f268c808ca280c08565e759309ea24f17dcd0808097b"
+checksum = "d9e7bdda614cb69c087d89d598ac4850e567be09f3de8d510b57147c111d5ce1"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -12609,13 +13103,13 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51104c3cab9d6c9e8361adbd487dd409a8343e740744fb0b3f983bc775fd1847"
+checksum = "6f7b352143ee888fc624adff978e32b2ee6cf81d659907190107e1c86e205eeb"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core",
+ "sp-core 33.0.1",
 ]
 
 [[package]]
@@ -12635,10 +13129,36 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
+ "sp-application-crypto 35.0.0",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a6148bf0ba74999ecfea9b4c1ade544f0663e0baba19630bb7761b2142b19"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 36.0.0",
+ "sp-arithmetic",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
  "sp-std",
  "sp-weights",
 ]
@@ -12670,26 +13190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
 dependencies = [
  "Inflector",
- "expander 2.1.0",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "sp-session"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c558f85486882433adcfdfe05c5e82972a7be1a6d7fa68a6213b70ec1d86068"
+checksum = "601e0203c52ac7c1122ad316ae4e5cc355fdf1d69ef5b6c4aa30f7a17921fad9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-api 32.0.0",
+ "sp-core 33.0.1",
+ "sp-keystore 0.39.0",
+ "sp-runtime 37.0.0",
+ "sp-staking 32.0.0",
 ]
 
 [[package]]
@@ -12702,8 +13222,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-runtime 36.0.0",
+]
+
+[[package]]
+name = "sp-staking"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817c02b55a84c0fac32fdd8b3f0b959888bad0726009ed62433f4046f4b4b752"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -12715,13 +13249,34 @@ dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "smallvec",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie",
+ "sp-trie 34.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6ac196ea92c4d0613c071e1a050765dbfa30107a990224a4aba02c7dbcd063"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 33.0.1",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie 35.0.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -12729,9 +13284,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac525ad4b3533aebdd68ae097d0a55887b6499b565c5a592f6c18372a40caf"
+checksum = "f857a29733a0240105d05f6d36bc7d760d814c22c6b12997f2d153236bfc8220"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -12741,12 +13296,12 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
+ "sp-core 33.0.1",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -12773,14 +13328,14 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb7768c895643e315f9bcfacdd61e283b78c862d976fd081a508cf7239c8643"
+checksum = "1d48d9246310340b11dc4f4c119fe93975c7c0c325637693da8c755d028fce19"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
  "thiserror",
 ]
 
@@ -12798,27 +13353,27 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207cb372504cf86237fa63953a0aa40d7596d1c9cf21175a56346ed1744eb8fe"
+checksum = "14de2a91e5a2bebaf47993644643c92564cafc55d55e1c854f6637ee62c90b4b"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1141f46e088898986a59c8aae4a91c8d8c04da22a38986a8bdfcb2446889ee5a"
+checksum = "aeca8215fb05fd67b4d72e39d8e3f0ed9a3cc86c95da95bc856ebc4c23f95c8f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-core 33.0.1",
+ "sp-inherents 32.0.0",
+ "sp-runtime 37.0.0",
+ "sp-trie 35.0.0",
 ]
 
 [[package]]
@@ -12833,11 +13388,35 @@ dependencies = [
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core",
+ "sp-core 32.0.0",
+ "sp-externalities",
+ "thiserror",
+ "tracing",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61ab0c3e003f457203702e4753aa5fe9e762380543fada44650b1217e4aa5a5"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "scale-info",
+ "schnellru",
+ "sp-core 33.0.1",
  "sp-externalities",
  "thiserror",
  "tracing",
@@ -12857,7 +13436,25 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 36.0.0",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff74bf12b4f7d29387eb1caeec5553209a505f90a2511d2831143b970f89659"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -12872,7 +13469,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12957,16 +13554,16 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd2f6285b97c1797f8451afb9834a90bd7b90712e6d1a3df8f68f9e7357ea6"
+checksum = "0473f6e6cd7296675188f88b2c29dccea328f9f88ccb18f3a79048505ce7dc2a"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-std",
 ]
 
@@ -12976,7 +13573,26 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5090e0801a8aeb28ff88cc6e0ca0bad399cc58eed11ec70c517fcb316bd3151b"
 dependencies = [
- "array-bytes 6.2.3",
+ "array-bytes",
+ "bounded-collections",
+ "derivative",
+ "environmental",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-weights",
+ "xcm-procedural",
+]
+
+[[package]]
+name = "staging-xcm"
+version = "13.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc905526a2619dfaa17d0d32d1daa6885fdf4eb2fead2e37411eb9d0a91013e"
+dependencies = [
+ "array-bytes",
  "bounded-collections",
  "derivative",
  "environmental",
@@ -12995,21 +13611,44 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ccd51b148ec7c72f98cd315952595af353c103f4ad76cb600a85b8ee60adf4"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 33.0.0",
+ "frame-system 33.0.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 33.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 11.0.0",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm 12.0.0",
+ "staging-xcm-executor 12.0.0",
+]
+
+[[package]]
+name = "staging-xcm-builder"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd94fb9634d6276b74b7ee9ec5b761c52c30ec40b7c0a381711c5d25c3a0141"
+dependencies = [
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-transaction-payment 34.0.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives 12.0.0",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-std",
+ "sp-weights",
+ "staging-xcm 13.0.1",
+ "staging-xcm-executor 13.0.0",
 ]
 
 [[package]]
@@ -13019,19 +13658,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39025611744d726ee1cb6661c09b13cd41525ca791f4fba45d68a00db9582063"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
+ "frame-benchmarking 33.0.0",
+ "frame-support 33.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-io 35.0.0",
+ "sp-runtime 36.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 12.0.0",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd7135969e580a14b73bf65fd25d714f3b20c3b2e94ff0949c148820ab3a79d"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 34.0.0",
+ "frame-support 34.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core 33.0.1",
+ "sp-io 36.0.0",
+ "sp-runtime 37.0.0",
+ "sp-std",
+ "sp-weights",
+ "staging-xcm 13.0.1",
 ]
 
 [[package]]
@@ -13089,6 +13750,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "str0m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f10d3f68e60168d81110410428a435dbde28cc5525f5f7c6fdec92dbdc2800"
+dependencies = [
+ "combine",
+ "crc",
+ "hmac 0.12.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rand 0.8.5",
+ "sctp-proto",
+ "serde",
+ "sha-1 0.10.1",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "strobe-rs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13119,7 +13800,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.2",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -13137,15 +13818,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13169,9 +13850,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19975c2965833aed97064cd34975ed5bc0390e4436c84b381874c8abce43712"
+checksum = "51bbe199ad82e3b69312a50b7024db70568d1bc1c4de6c21d89a2efd6cd59104"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -13180,11 +13861,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
 ]
 
 [[package]]
@@ -13202,19 +13883,19 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538029eeb26c9ab3f5f8677d696336f92ee536918f4e7ba7fcad1d08ad31ca6b"
+checksum = "6ec3140547debbca2c3cfa23d4d1b3e08761c09f67ac6fa5c9467b7f82d3e4e9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
+ "sp-state-machine 0.41.0",
+ "sp-trie 35.0.0",
  "trie-db",
 ]
 
@@ -13224,25 +13905,16 @@ version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6567b61eca9459dbe71385caef9f6eab826abbd4a0743abf27034d96d34b9062"
 dependencies = [
- "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata",
- "merkleized-metadata",
- "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
- "sc-executor",
- "sp-core",
- "sp-io",
  "sp-maybe-compressed-blob",
- "sp-tracing",
- "sp-version",
  "strum 0.26.2",
  "tempfile",
- "toml 0.8.13",
+ "toml 0.8.14",
  "walkdir",
  "wasm-opt",
 ]
@@ -13278,9 +13950,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13297,6 +13969,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13395,7 +14078,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13406,7 +14089,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13509,6 +14192,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13525,16 +14218,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project-lite 0.2.14",
  "signal-hook-registry",
  "socket2 0.5.7",
@@ -13544,13 +14237,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13626,14 +14319,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -13647,9 +14340,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
@@ -13669,15 +14362,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -13745,7 +14438,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13770,9 +14463,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d037e38c3da801f670c99e555882a8009c40a8a473815e6a4ea72a8e2887c0c4"
+checksum = "518b1159d234d0833152f6f60501ed28a04e9e263293746dad886ec0a8bb20e7"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13786,11 +14479,11 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f074568687ffdfd0adb6005aa8d1d96840197f2c159f80471285f08694cf0ce"
 dependencies = [
- "expander 2.1.0",
+ "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -13856,7 +14549,7 @@ dependencies = [
  "matchers 0.1.0",
  "nu-ansi-term",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -13949,7 +14642,7 @@ dependencies = [
  "ipconfig",
  "lazy_static",
  "lru-cache",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -13969,7 +14662,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
@@ -14070,9 +14763,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -14117,12 +14810,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.0",
  "percent-encoding",
 ]
 
@@ -14133,10 +14826,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -14164,9 +14869,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7335e4c132c28cc43caef6adb339789e599e39adbe78da0c4d547fad48cbc331"
+checksum = "9c5da5fa2c6afa2c9158eaa7cd9aee249765eb32b5fb0c63ad8b9e79336a47ec"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -14253,7 +14958,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -14287,7 +14992,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -14638,17 +15343,17 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acc56783ce7fca15017890034ed043cb91de2caab28a91a5b4209a1214eed4"
+checksum = "01b641fb4783e441a32ddc3e3f7927a6092cec39af9de2f85becacba412b6815"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 34.0.0",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 34.0.0",
+ "frame-system 34.0.1",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -14659,7 +15364,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances",
+ "pallet-balances 35.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -14696,7 +15401,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 34.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -14705,7 +15410,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 12.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -14714,30 +15419,30 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 32.0.0",
+ "sp-application-crypto 36.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-core 33.0.1",
+ "sp-genesis-builder 0.13.0",
+ "sp-inherents 32.0.0",
+ "sp-io 36.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 37.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 32.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "sp-version 35.0.0",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
+ "staging-xcm-executor 13.0.0",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-fee-payment-runtime-api",
@@ -14745,19 +15450,19 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb9a91bc8d5ec0a260735651284eb4420c1a2de62b2430cf16c723186eabd28"
+checksum = "55241a1b789ae6acf4bbe62687f2876fa83b151abf3d94e275c92ba4a2b59fe8"
 dependencies = [
- "frame-support",
+ "frame-support 34.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core",
- "sp-runtime",
+ "sp-core 33.0.1",
+ "sp-runtime 37.0.0",
  "sp-weights",
- "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm 13.0.1",
+ "staging-xcm-builder 13.0.0",
 ]
 
 [[package]]
@@ -14774,9 +15479,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.20"
+version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e005a4cc35784183a9e39cb22e9a9c46353ef6a7f113fd8d36ddc58c15ef3c"
+checksum = "8a040b111774ab63a19ef46bbc149398ab372b4ccdcfd719e9814dbd7dfd76c8"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -15078,9 +15783,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -15094,6 +15799,18 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -15164,18 +15881,18 @@ dependencies = [
 
 [[package]]
 name = "xcm-fee-payment-runtime-api"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92be74937c8012c951c667bb0fb016634ab4adeac46f8106aef331f836059167"
+checksum = "a08b02854d1e3f844dec37dcf5897524f8e7ac6f227d225cba4ab43dadd0b691"
 dependencies = [
- "frame-support",
+ "frame-support 34.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 32.0.0",
+ "sp-runtime 37.0.0",
  "sp-std",
  "sp-weights",
- "staging-xcm",
+ "staging-xcm 13.0.1",
 ]
 
 [[package]]
@@ -15187,7 +15904,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -15199,7 +15916,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -15211,6 +15928,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -15230,14 +15971,35 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -15250,7 +16012,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -15293,9 +16077,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ substrate-frame-rpc-system = "34.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
-pallet-contracts = { version = "32.0.0", default-features = false }
+pallet-contracts = { version = "33.0.0", default-features = false }
 
 # Polkadot
 pallet-xcm = { version = "13.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,119 +9,121 @@ license = "Unlicense"
 repository = "https://github.com/r0gue-io/base-parachain"
 
 [workspace]
-members = [
-    "node",
-    "runtime",
-]
+members = ["node", "runtime"]
 resolver = "2"
 
 [workspace.dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
 color-print = "0.3.4"
+docify = "0.2.8"
 futures = "0.3.30"
 hex-literal = "0.4.1"
 jsonrpsee = { version = "0.22", features = ["server"] }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = [
+    "derive",
+] }
 serde = "1.0.197"
 serde_json = "1.0.114"
 smallvec = "1.11.2"
 
 # Build
 substrate-build-script-utils = "11.0.0"
-substrate-wasm-builder = "22.0.1"
-docify = "0.2.8"
+substrate-wasm-builder = "22.0.0"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-frame-benchmarking = { version = "33.0.0", default-features = false }
-frame-benchmarking-cli = "37.0.0"
-frame-executive = { version = "33.0.0", default-features = false }
-frame-metadata-hash-extension = { version = "0.2.0", default-features = false }
-frame-support = { version = "33.0.0", default-features = false }
-frame-system = { version = "33.0.0", default-features = false }
-frame-system-benchmarking = { version = "33.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "31.0.0", default-features = false }
-frame-try-runtime = { version = "0.39.0", default-features = false }
-pallet-aura = { version = "32.0.0", default-features = false }
-pallet-authorship = { version = "33.0.0", default-features = false }
-pallet-balances = { version = "34.0.0", default-features = false }
-pallet-message-queue = { version = "36.0.0", default-features = false }
-pallet-session = { version = "33.0.0", default-features = false }
-pallet-sudo = { version = "33.0.0", default-features = false }
-pallet-timestamp = { version = "32.0.0", default-features = false }
-pallet-transaction-payment = { version = "33.0.0", default-features = false }
-pallet-transaction-payment-rpc = "35.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "33.0.0", default-features = false }
-sc-basic-authorship = "0.39.0"
-sc-chain-spec = "32.0.0"
-sc-cli = "0.41.0"
-sc-client-api = "33.0.0"
-sc-offchain = "34.0.0"
-sc-consensus = "0.38.0"
-sc-executor = "0.37.0"
-sc-network = "0.39.0"
-sc-network-sync = "0.38.0"
-sc-rpc = "34.0.0"
-sc-service = "0.40.0"
-sc-sysinfo = "32.0.0"
-sc-telemetry = "19.0.0"
-sc-tracing = "33.0.0"
-sc-transaction-pool = "33.0.0"
-sc-transaction-pool-api = "33.0.0"
-sp-api = { version = "31.0.0", default-features = false }
-sp-block-builder = { version = "31.0.0", default-features = false }
-sp-blockchain = "33.0.0"
-sp-consensus-aura = { version = "0.37.0", default-features = false }
-sp-core = { version = "32.0.0", default-features = false }
-sp-io = { version = "35.0.0", default-features = false }
-sp-genesis-builder = { version = "0.12.0", default-features = false }
-sp-inherents = { version = "31.0.0", default-features = false }
-sp-keystore = "0.38.0"
-sp-offchain = { version = "31.0.0", default-features = false }
-sp-runtime = { version = "36.0.0", default-features = false }
-sp-session = { version = "32.0.0", default-features = false }
+frame-benchmarking = { version = "34.0.0", default-features = false }
+frame-benchmarking-cli = "38.0.0"
+frame-executive = { version = "34.0.0", default-features = false }
+frame-support = { version = "34.0.0", default-features = false }
+frame-system = { version = "34.0.1", default-features = false }
+frame-system-benchmarking = { version = "34.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "32.0.0", default-features = false }
+frame-try-runtime = { version = "0.40.0", default-features = false }
+pallet-aura = { version = "33.0.0", default-features = false }
+pallet-authorship = { version = "34.0.0", default-features = false }
+pallet-balances = { version = "35.0.0", default-features = false }
+pallet-message-queue = { version = "37.0.0", default-features = false }
+pallet-session = { version = "34.0.0", default-features = false }
+pallet-sudo = { version = "34.0.0", default-features = false }
+pallet-timestamp = { version = "33.0.0", default-features = false }
+pallet-transaction-payment = { version = "34.0.0", default-features = false }
+pallet-transaction-payment-rpc = "36.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "34.0.0", default-features = false }
+sc-basic-authorship = "0.40.0"
+sc-chain-spec = "33.0.0"
+sc-cli = "0.42.0"
+sc-client-api = "34.0.0"
+sc-offchain = "35.0.0"
+sc-consensus = "0.39.1"
+sc-executor = "0.38.0"
+sc-network = "0.40.0"
+sc-network-sync = "0.39.0"
+sc-rpc = "35.0.0"
+sc-service = "0.41.0"
+sc-sysinfo = "33.0.0"
+sc-telemetry = "20.0.0"
+sc-tracing = "34.0.0"
+sc-transaction-pool = "34.0.0"
+sc-transaction-pool-api = "34.0.0"
+sp-api = { version = "32.0.0", default-features = false }
+sp-block-builder = { version = "32.0.0", default-features = false }
+sp-blockchain = "34.0.0"
+sp-consensus-aura = { version = "0.38.0", default-features = false }
+sp-core = { version = "33.0.1", default-features = false }
+sp-io = { version = "36.0.0", default-features = false }
+sp-genesis-builder = { version = "0.13.0", default-features = false }
+sp-inherents = { version = "32.0.0", default-features = false }
+sp-keystore = "0.39.0"
+sp-offchain = { version = "32.0.0", default-features = false }
+sp-runtime = { version = "37.0.0", default-features = false }
+sp-session = { version = "33.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = "31.0.0"
-sp-transaction-pool = { version = "31.0.0", default-features = false }
-sp-version = { version = "34.0.0", default-features = false }
-substrate-frame-rpc-system = "33.0.0"
+sp-timestamp = "32.0.0"
+sp-transaction-pool = { version = "32.0.0", default-features = false }
+sp-version = { version = "35.0.0", default-features = false }
+substrate-frame-rpc-system = "34.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
 pallet-contracts = { version = "32.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "12.0.0", default-features = false }
-polkadot-cli = "12.0.0"
-polkadot-parachain-primitives = { version = "11.0.0", default-features = false }
-polkadot-primitives = "12.0.0"
-polkadot-runtime-common = { version = "12.0.0", default-features = false }
-xcm = { version = "12.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "12.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "12.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "13.0.0", default-features = false }
+polkadot-cli = "13.0.0"
+polkadot-parachain-primitives = { version = "12.0.0", default-features = false }
+polkadot-primitives = "13.0.0"
+polkadot-runtime-common = { version = "13.0.0", default-features = false }
+xcm = { version = "13.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "13.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "13.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.12.0"
-cumulus-client-collator = "0.12.0"
-cumulus-client-consensus-aura = "0.12.0"
-cumulus-client-consensus-common = "0.12.0"
-cumulus-client-consensus-proposer = "0.12.0"
-cumulus-client-service = "0.12.0"
-cumulus-pallet-aura-ext = { version = "0.12.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.12.0", default-features = false, features = ["parameterized-consensus-hook"] }
-cumulus-pallet-session-benchmarking = { version = "14.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.12.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.12.0", default-features = false }
-cumulus-primitives-aura = { version = "0.12.0", default-features = false }
-cumulus-primitives-core = { version = "0.12.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.12.0"
-cumulus-primitives-storage-weight-reclaim = { version = "3.0.0", default-features = false }
-cumulus-primitives-utility = { version = "0.12.0", default-features = false }
-cumulus-relay-chain-interface = "0.12.0"
-pallet-collator-selection = { version = "14.0.0", default-features = false }
-parachains-common = { version = "12.0.0", default-features = false }
-parachain-info = { version = "0.12.0", package = "staging-parachain-info", default-features = false }
+cumulus-client-cli = "0.13.0"
+cumulus-client-collator = "0.13.0"
+cumulus-client-consensus-aura = "0.13.0"
+cumulus-client-consensus-common = "0.13.0"
+cumulus-client-consensus-proposer = "0.13.0"
+cumulus-client-service = "0.13.0"
+cumulus-pallet-aura-ext = { version = "0.13.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.13.0", default-features = false, features = [
+    "parameterized-consensus-hook",
+] }
+cumulus-pallet-session-benchmarking = { version = "15.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.13.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.13.0", default-features = false }
+cumulus-primitives-aura = { version = "0.13.0", default-features = false }
+cumulus-primitives-core = { version = "0.13.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.13.0"
+cumulus-primitives-storage-weight-reclaim = { version = "4.0.0", default-features = false }
+cumulus-primitives-utility = { version = "0.13.0", default-features = false }
+cumulus-relay-chain-interface = "0.13.0"
+pallet-collator-selection = { version = "15.0.0", default-features = false }
+parachains-common = { version = "13.0.0", default-features = false }
+parachain-info = { version = "0.13.0", package = "staging-parachain-info", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ substrate-build-script-utils.workspace = true
 clap.workspace = true
 codec.workspace = true
 color-print.workspace = true
+docify.workspace = true
 futures.workspace = true
 jsonrpsee.workspace = true
 log.workspace = true

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -22,11 +22,12 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 
 /// The extensions for the [`ChainSpec`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
-#[serde(deny_unknown_fields)]
 pub struct Extensions {
     /// The relay chain of the Parachain.
+    #[serde(alias = "relayChain", alias = "RelayChain")]
     pub relay_chain: String,
     /// The id of the Parachain.
+    #[serde(alias = "paraId", alias = "ParaId")]
     pub para_id: u32,
 }
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -39,6 +39,7 @@ use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sp_keystore::KeystorePtr;
 use substrate_prometheus_endpoint::Registry;
 
+#[docify::export(wasm_executor)]
 type ParachainExecutor = WasmExecutor<ParachainHostFunctions>;
 
 type ParachainClient = TFullClient<Block, RuntimeApi, ParachainExecutor>;
@@ -65,6 +66,7 @@ pub type Service = PartialComponents<
 ///
 /// Use this macro if you don't actually need the full service, but just the builder in order to
 /// be able to perform chain operations.
+#[docify::export(component_instantiation)]
 pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error> {
     let telemetry = config
         .telemetry_endpoints
@@ -337,7 +339,7 @@ pub async fn start_parachain_node(
         config: parachain_config,
         keystore: params.keystore_container.keystore(),
         backend: backend.clone(),
-        network: network.clone(),
+        network: network,
         sync_service: sync_service.clone(),
         system_rpc_tx,
         tx_handler_controller,
@@ -405,9 +407,9 @@ pub async fn start_parachain_node(
             prometheus_registry.as_ref(),
             telemetry.as_ref().map(|t| t.handle()),
             &task_manager,
-            relay_chain_interface.clone(),
+            relay_chain_interface,
             transaction_pool,
-            sync_service.clone(),
+            sync_service,
             params.keystore_container.keystore(),
             relay_chain_slot_duration,
             para_id,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,11 +22,11 @@ hex-literal.workspace = true
 log.workspace = true
 scale-info.workspace = true
 smallvec.workspace = true
+docify.workspace = true
 
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive.workspace = true
-frame-metadata-hash-extension.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -80,57 +80,56 @@ parachain-info.workspace = true
 [features]
 default = ["std"]
 std = [
-	"codec/std",
-	"cumulus-pallet-aura-ext/std",
-	"cumulus-pallet-parachain-system/std",
-	"cumulus-pallet-session-benchmarking/std",
-	"cumulus-pallet-xcm/std",
-	"cumulus-pallet-xcmp-queue/std",
-	"cumulus-primitives-aura/std",
-	"cumulus-primitives-core/std",
-	"cumulus-primitives-storage-weight-reclaim/std",
-	"cumulus-primitives-utility/std",
-	"frame-benchmarking/std",
-	"frame-executive/std",
-	"frame-metadata-hash-extension/std",
-	"frame-support/std",
-	"frame-system-benchmarking/std",
-	"frame-system-rpc-runtime-api/std",
-	"frame-system/std",
-	"frame-try-runtime/std",
-	"log/std",
-	"pallet-aura/std",
-	"pallet-authorship/std",
-	"pallet-balances/std",
-	"pallet-collator-selection/std",
+    "codec/std",
+    "cumulus-pallet-aura-ext/std",
+    "cumulus-pallet-parachain-system/std",
+    "cumulus-pallet-session-benchmarking/std",
+    "cumulus-pallet-xcm/std",
+    "cumulus-pallet-xcmp-queue/std",
+    "cumulus-primitives-aura/std",
+    "cumulus-primitives-core/std",
+    "cumulus-primitives-storage-weight-reclaim/std",
+    "cumulus-primitives-utility/std",
+    "frame-benchmarking/std",
+    "frame-executive/std",
+    "frame-support/std",
+    "frame-system-benchmarking/std",
+    "frame-system-rpc-runtime-api/std",
+    "frame-system/std",
+    "frame-try-runtime/std",
+    "log/std",
+    "pallet-aura/std",
+    "pallet-authorship/std",
+    "pallet-balances/std",
+    "pallet-collator-selection/std",
 	"pallet-contracts/std",
-	"pallet-message-queue/std",
-	"pallet-session/std",
-	"pallet-sudo/std",
-	"pallet-timestamp/std",
-	"pallet-transaction-payment-rpc-runtime-api/std",
-	"pallet-transaction-payment/std",
-	"pallet-xcm/std",
-	"parachain-info/std",
-	"parachains-common/std",
-	"polkadot-parachain-primitives/std",
-	"polkadot-runtime-common/std",
-	"scale-info/std",
-	"sp-api/std",
-	"sp-block-builder/std",
-	"sp-consensus-aura/std",
-	"sp-core/std",
-	"sp-genesis-builder/std",
-	"sp-inherents/std",
-	"sp-offchain/std",
-	"sp-runtime/std",
-	"sp-session/std",
-	"sp-std/std",
-	"sp-transaction-pool/std",
-	"sp-version/std",
-	"xcm-builder/std",
-	"xcm-executor/std",
-	"xcm/std",
+    "pallet-message-queue/std",
+    "pallet-session/std",
+    "pallet-sudo/std",
+    "pallet-timestamp/std",
+    "pallet-transaction-payment-rpc-runtime-api/std",
+    "pallet-transaction-payment/std",
+    "pallet-xcm/std",
+    "parachain-info/std",
+    "parachains-common/std",
+    "polkadot-parachain-primitives/std",
+    "polkadot-runtime-common/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-block-builder/std",
+    "sp-consensus-aura/std",
+    "sp-core/std",
+    "sp-genesis-builder/std",
+    "sp-inherents/std",
+    "sp-offchain/std",
+    "sp-runtime/std",
+    "sp-session/std",
+    "sp-std/std",
+    "sp-transaction-pool/std",
+    "sp-version/std",
+    "xcm-builder/std",
+    "xcm-executor/std",
+    "xcm/std",
 ]
 
 runtime-benchmarks = [
@@ -182,16 +181,3 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
-
-# Enable the metadata hash generation.
-#
-# This is hidden behind a feature because it increases the compile time.
-# The wasm binary needs to be compiled twice, once to fetch the metadata,
-# generate the metadata hash and then a second time with the
-# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
-# extension.
-metadata-hash = ["substrate-wasm-builder/metadata-hash"]
-
-# A convenience feature for enabling things when doing a build
-# for an on-chain release.
-on-chain-release-build = ["metadata-hash"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,17 +1,7 @@
-#[cfg(all(feature = "std", feature = "metadata-hash"))]
-#[docify::export(template_enable_metadata_hash)]
-fn main() {
-    substrate_wasm_builder::WasmBuilder::init_with_defaults()
-        .enable_metadata_hash("UNIT", 12)
-        .build();
-}
-
-#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
+#[cfg(feature = "std")]
 fn main() {
     substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
-/// The wasm builder is deactivated when compiling
-/// this crate for wasm to speed up the compilation.
 #[cfg(not(feature = "std"))]
 fn main() {}

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -129,7 +129,7 @@ impl pallet_timestamp::Config for Runtime {
     /// A timestamp: milliseconds since the unix epoch.
     type Moment = u64;
     type OnTimestampSet = Aura;
-    type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+    type MinimumPeriod = ConstU64<0>;
     type WeightInfo = (); // Configure based on benchmarking results.
 }
 

--- a/runtime/src/configs/xcm.rs
+++ b/runtime/src/configs/xcm.rs
@@ -197,6 +197,7 @@ impl xcm_executor::Config for XcmConfig {
     type HrmpNewChannelOpenRequestHandler = ();
     type HrmpChannelAcceptedHandler = ();
     type HrmpChannelClosingHandler = ();
+    type XcmRecorder = PolkadotXcm;
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -99,6 +99,7 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 
 /// The SignedExtension to the basic transaction logic.
+#[docify::export(template_signed_extra)]
 pub type SignedExtra = (
     frame_system::CheckNonZeroSender<Runtime>,
     frame_system::CheckSpecVersion<Runtime>,
@@ -109,7 +110,6 @@ pub type SignedExtra = (
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
-    frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
Followed the same process as described in the previous upgrade: https://github.com/r0gue-io/assets-parachain/pull/5

This will temporarily fix this issue https://github.com/r0gue-io/pop-cli/issues/270 (Until we add the frame metadata signed [extension](https://github.com/paritytech/polkadot-sdk/blob/d5160c1d567cc73c7df6c816d41e21aa3adb188d/templates/parachain/runtime/src/lib.rs#L89))