### PR TITLE
chore: upgrade to polkadot v1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493c8238552fb50edfe9c3eb94e8058fce36cce71cc9ad0fb1902d3aedcd902"
+checksum = "b7dae4d1ec894ee920195dd39070b279ef3c1d4d078c3fcf7336c93a1d502a9d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85253f32659117ed1f4aa213e3257dcc022be89f091be91dc83993de5ed8d060"
+checksum = "7980387e86a9447caa3c3aa2a0c908e6dc94d81e5494c12e56146a6271204b31"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1629,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6197f6736982d38c34ee006f3bb71760a52dd87fdbc65798088c2916d18469d"
+checksum = "1291bce46c865d627075f7f1d980e22b011dbe670cacea6b0b9c95f83eb4ebdd"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04552e4aa9eaa59be930ee23a910f0c41ba3e6d9e725cc21808c11fe8eb8f09"
+checksum = "fe170ff77c66f15afe0ce18940f51f78920d80215165c919469516be57108e59"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81828c28d9a38669f45420d31d18580760381ae86e1b2ecd2a426f1e57ce74fb"
+checksum = "cca21fecfbeedaabf25c421573dfe3e3392d376e2b4acd4a281062ad142ce1b9"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf30d94b3abfd99cef2e99ce0314bcd4f17d973bc02cee867f32171644a8191"
+checksum = "56e980b3e5c05415eaa4ac07f398bc8e74666811f3112f19a654ccb3a948018e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcfd3ecd531f3f8a83c6d39715e6e1804cb70da0d162706c0e82de90003407b"
+checksum = "7d9d520c245f0df156dc50a86dfec79efcda7733a99eeb2224e315a26eab4650"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fd3787124724561055fe7178866120ecf47e30f72d90ef9299233d74e32a66"
+checksum = "9ff5587b8a306617db8f6528f9244c6ee4344745eeb252b3c7b20ea6c2496b3c"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3fc23f6dc74dc346bee76554b581d72ffe5bbe2b26d44a210559012c9732e0"
+checksum = "ca43387c87d4b6fb2f8ff5ac70e46b7bea0ff686b6445e8bd4b6e44691d6616e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cb06d29f61d047814a32070014ad259dae1ec0a4426c9474991952de8b21d7"
+checksum = "5c6b433d3036a30f2aaacd4249988084f55ca3291c9388fa7e78e4b6222f74ef"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98aaa88ee4435475935579907b03e4f60b086c6878945868a4d4e31510957431"
+checksum = "52088d88534bd04ea251c030af1fef69845d29ed4fc9be399c1fbd5a311bea61"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -1873,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9224798d18e22f3847b2d513dcb8db5611f8ddd62813da81154f9cfe95c2d78"
+checksum = "95f75a9e4dfebf1850c7c946a49cdb8b5e82a143155a40337ea083f412e13071"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f32808caa41da9a1db60e1de9e7ba84eb7370067f481ecc7ceb137aede0ac5"
+checksum = "5d45ca03e091945ecbb293df36823202ce3eba6133454968bf54e3f82c1b58ee"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bfe7a26ebf90b71ab9cb75f983f29d9a2a47205fabde8ad6d8589c629f1851"
+checksum = "dccf061aecc7c4b393c6586a0d95900bc0dfc8ac9298313a608d2389bf7f8de2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89d7c1ee618846a05153082bb30408ef574227899d2b3d20ec1dd234649a076"
+checksum = "437a52fc63387f1aa2211bc219e1283a935ed36d9ccbb3373faee0398125c466"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35269d04c8b6a775be07c49e5512f383d455bb91fe951adef8c72d45600a9acd"
+checksum = "3e7977947ad43a4cbc532ca33abcde136ae3deffdc7168b2ae253d73ccd371e4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8947e8b09cef060025d11a8da171f698da4d9b67191b5bc3f96d6cec553f17d"
+checksum = "751e64b89a839d5cfabebc1c797936e5eee791d0fa2322d91e86f8440a743ddb"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698272736111f59f0b8c88cfa8586ef943b355958da683676e753af9f351a06a"
+checksum = "df521e13b48278b86d02c61d6e44036d6d263deb5aaec4838b1751da8988d3d2"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2032,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f815c73e6d8a5b44daac8881770137a99364d4c531ae9a21b2e6909a889631f1"
+checksum = "9f973d2a7262c90e48dcd42062bcb1e0fbf48bbcdac4ea6df3d85212d8d8be5d"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2043,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d48fbf5b0f5b43df5811fdf3efd5c16517960885e51e7de79bf3f7def8c25b9"
+checksum = "4ea10ccbf595c8b2e6dd34dcf8f5f213d6dd5e3de0f73b1eae71045ac04c692f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3195604b37c3de5407201cf77deabb4436a6ddb2db6206bc72aa6a356402532e"
+checksum = "192d7917d70fdb0998311df31430bd28408af9abce79a2245efbf511a8fa4671"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10278c5ed258ba0ca63cfa103cacc3d15b95f2b0044557a57653188ef76d5e3"
+checksum = "14d271cbd47783a94e4cb9db3ef34c4e4e05773e16bb6ec766f2ea9939d84644"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2107,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dfb9dc86a639df592a99272aadd6bcba50ba4d183c35525c32e0c8b33f085bd"
+checksum = "6f324e573f19f7d4478f19f8e58dd922024712fd9c656e8a3112ee7d7ff3f414"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd2da7aef1dfb8257ba4358cb7f41d032361417db10835bf8cff00e2a781fc6"
+checksum = "17aeea632dad3e8251c85ea6a2e5c8deed7f69b6465671347106de27bfcdc70a"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2169,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70504899cac7553fd5866586e4a5229c6da52091be78893271e0c1972064ad"
+checksum = "7f292767910d0e65aa52b350b606a8a8d0990c6a780abad5d8358f25b0280405"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09720b54033b0f2ee3d254a90cfecf62a46db5c8ce16cc893218e7662662d507"
+checksum = "e1f4ab9d64a581d4a5431f2554f4602a4208c5e28b30be01af386e24d8447599"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2405,17 +2405,6 @@ dependencies = [
 
 [[package]]
 name = "derive-syn-parse"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-syn-parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
@@ -2543,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
 dependencies = [
  "common-path",
- "derive-syn-parse 0.2.0",
+ "derive-syn-parse",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3081,9 +3070,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130b79108bca3d8850e850c276f1012058593d6a2a8774132e72766245bbcacc"
+checksum = "ad6366773db71a556710652c0560300dc938252e009d4d2c1eb9d6e5b38e0860"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3107,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13238d7648598b5476ddbf87c8633eb299c1f872e93c9afc874a1419e6e990d2"
+checksum = "9bff993810ef24391487012e6b8e42ee0909e51e95954046849f0eb56236e4d5"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3158,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "13.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c3bff645e46577c69c272733c53fa3a77d1ee6e40dfb66157bc94b0740b8fc"
+checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -3170,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e498d8b21ba927024302645e0f4d0d0136c9620808d8425bb309fb8a92d3ff"
+checksum = "b3c089c16a066dfb5042cadc27c01738d93258e8f5f7ef7a83b4c8661616d1ac"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3188,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ab937cea917f5875b0e08d55ed941f9c82c2b08628d6bf47b90c63c48ef607"
+checksum = "9287dd6070c0ca90b42c9b4fc44f2bc91adf08b73c11c74484c416f0cc9abe04"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3219,10 +3208,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-support"
-version = "34.0.0"
+name = "frame-metadata-hash-extension"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c177377726d7bb598dd942e38168c1eb6872d53810a6bf810f0a428f9a46be8"
+checksum = "ba1fa15dc90efe948898c06a3be111628230db100ffa2907e662062e9c9d1abd"
+dependencies = [
+ "array-bytes",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
+name = "frame-support"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6d7780b7f337c8a072f0a7480cbc7b580f9bf871c434fae65e8935053ee5ef"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3262,13 +3267,13 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f822826825d810d0e096e70493cbc1032ff3ccf1324d861040865635112b6aa"
+checksum = "fd94af68373e179c32c360b3c280497a9cf0f45a4f47f0ee6539a6c6c9cf2343"
 dependencies = [
  "Inflector",
  "cfg-expr",
- "derive-syn-parse 0.2.0",
+ "derive-syn-parse",
  "expander",
  "frame-support-procedural-tools",
  "itertools 0.11.0",
@@ -3282,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b5cc8526c9aad01cdf46dcee6cbefd6f6c78e022607ff4cf76094919b6462"
+checksum = "bead15a320be1764cdd50458c4cfacb23e0cee65f64f500f8e34136a94c7eeca"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -3306,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "34.0.1"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85777d5cb78d8f244aa4e92a06d13c234f7980dd7095b1baeefc23a5945cad6c"
+checksum = "6baa2218d90c5a23db08dd0188cfe6aa0af7d36fb9b0fc2f73bc5c4abe4dd812"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3327,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2df1ebcb669ae29aec03f6f87b232f2446942fb79fad72434d8d0a0fd7df917"
+checksum = "be45f57aefef5fa97fce1482dc1ede197620d8b0bb588b3cec8d84f32557cf8b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3343,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd92e3fe18b93d456efdabbd98070a1d720be5b6affe589379db9b7d9272eba5"
+checksum = "c9e9e2b7b85e451e367f4fb85ff3295bd039e17f64de1906154d3976e2638ee8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3353,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748a6c8286447388ff7a35d88fc2e0be3b26238c609c88b7774615c274452413"
+checksum = "8f2b9c95e0b38d713a46bb71bc395d4ed067c7a0f5370e13282c07c91fd1ec0d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3960,7 +3965,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -4335,15 +4340,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5151,9 +5147,9 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "litep2p"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b53e78902be9d0d77df70677242b7fc9815a33a168949b5480ee089e16535e7"
+checksum = "7f02542ae3a94b4c4ffa37dc56388c923e286afa3bf65452e3984b50b2a2f316"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",
@@ -5165,7 +5161,7 @@ dependencies = [
  "hex-literal",
  "indexmap 2.2.6",
  "libc",
- "mockall",
+ "mockall 0.12.1",
  "multiaddr",
  "multihash 0.17.0",
  "network-interface",
@@ -5186,62 +5182,7 @@ dependencies = [
  "snow",
  "socket2 0.5.7",
  "static_assertions",
- "str0m 0.2.0",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tokio-util",
- "tracing",
- "trust-dns-resolver 0.23.2",
- "uint",
- "unsigned-varint",
- "url",
- "webpki",
- "x25519-dalek 2.0.1",
- "x509-parser 0.15.1",
- "yasna",
- "zeroize",
-]
-
-[[package]]
-name = "litep2p"
-version = "0.4.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f680216510836ee5211c91d80add8d1b5ba2628a61b6d17263e6539e577a2cab"
-dependencies = [
- "async-trait",
- "bs58 0.4.0",
- "bytes",
- "cid 0.10.1",
- "ed25519-dalek 1.0.1",
- "futures",
- "futures-timer",
- "hex-literal",
- "indexmap 2.2.6",
- "libc",
- "mockall",
- "multiaddr",
- "multihash 0.17.0",
- "network-interface",
- "nohash-hasher",
- "parking_lot 0.12.3",
- "pin-project",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "quinn",
- "rand 0.8.5",
- "rcgen",
- "ring 0.16.20",
- "rustls 0.20.9",
- "serde",
- "sha2 0.10.8",
- "simple-dns",
- "smallvec",
- "snow",
- "socket2 0.5.7",
- "static_assertions",
- "str0m 0.4.1",
+ "str0m",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5330,9 +5271,9 @@ dependencies = [
 
 [[package]]
 name = "macro_magic"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03844fc635e92f3a0067e25fa4bf3e3dbf3f2927bf3aa01bb7bc8f1c428949d"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
 dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
@@ -5342,12 +5283,12 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468155613a44cfd825f1fb0ffa532b018253920d404e6fca1e8d43155198a46d"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
 dependencies = [
  "const-random",
- "derive-syn-parse 0.1.5",
+ "derive-syn-parse",
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
@@ -5356,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_core_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5367,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "macro_magic_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
@@ -5468,6 +5409,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5543,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663618e90cf942896a983beeec6bd1c4b25f30cabc1a54d16627866611dd7088"
+checksum = "0110fde66cc10e924e66aae0f85ac8a23e7eef2f2deea3c46b04c483ddf8e4e0"
 dependencies = [
  "futures",
  "log",
@@ -5563,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ae3285ed10596e5d6c0f7ac651fae1dd04155ee874e55311c6885fa8435ecd"
+checksum = "a2ea4f2bdf0784e901b9c7999c0e2c903bb2a6e10ca9f63214a1a6de8bdc8e21"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5587,8 +5542,23 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
- "predicates",
+ "mockall_derive 0.11.4",
+ "predicates 2.1.5",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive 0.12.1",
+ "predicates 3.1.2",
  "predicates-tree",
 ]
 
@@ -5602,6 +5572,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6210,9 +6192,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7428d88b215ade92402d6c01ad02f51b6bba02c69fab8c174e0b223b335d773"
+checksum = "0e9f1c4496f1c366a3ee01b38ba968589db41f5d44c41331111ff5a07964dbde"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6230,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ebd9fbc2bdd0015bc015103a596035de2b41d01f339f7fe732885fbd774ba0"
+checksum = "e83f523d209396ba42743008b64fe021eb6411a8d5ac868978636f0341feacc4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6246,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428dad50f10165a0d9757443733e38c94f371578fe44c9c989457d2cd61080ed"
+checksum = "7686ab6ba85afc432794a9dbc3e7399cb1a3b1bcfdd487ce0eb2aa81c11c2497"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6265,9 +6247,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce4a9e4704ec26889ed2245064d389251a04314c144239c08c9340ea5e14d1e"
+checksum = "5a58bb6d37a23df83b861e148129dc0130a4b80291f2c9dda3491989ec4c3662"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6282,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cfc84d2d716e23948f9777f97cf1c57461d33b22dcceeeb03493b3ad1059b"
+checksum = "638e3cbb539540e45503f5ae756b6bbb4e6085269d025afa273e684782f514ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6300,9 +6282,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9b476d5331907127d707a184f5454c8ded644c1530115241a576c578ecdfea"
+checksum = "3a5fafb21222ab509f0d9d4bda52730eb342574a0733321e1105e14d5454d6d5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6317,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd3d28c92dff65f0d198e88e3689f5282903138102bff84cc3794a1426665fc"
+checksum = "b134d987dfc6f2ddc3b4470672318fd59e740868485a25ec15ba909c42e6a622"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6332,9 +6314,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43127ee85b3a00650557a269efe1409f192df52e01abbed18dbaee9b5ccc174d"
+checksum = "84fa5a4406cd9f43babb90ce6e8f1598d36695c86c8e35094ec4cbf3224086fd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6357,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597db43f545daa97771c2c84f8d53e7b6596a37f58fe28329b221cfc45cb7575"
+checksum = "381526d7d765b4c895efa9da7c7f7b1965f251de6fe30757a63f535a021f2b69"
 dependencies = [
  "aquamarine",
  "docify",
@@ -6380,9 +6362,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bd03d979e84ec22862e62bece760601c10cc72712aa1fc43358ae9837dc9fd"
+checksum = "8dfe056082a1d857b0731572d7f9a96d98356b8610b258814cf75a55cd43c435"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6397,9 +6379,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a8f4f497878782988bdd7df0a825b4757921804fb7bafcc8df3b9e990c7a0"
+checksum = "6005abf441b2c6fc21505f0d3e00a66e40759ddff0311834f3f8ae2c5874b0e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6418,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e144caa40bc9a8b2947a0de2cb5eae3e701790bf9c2105536b6943d234aa7e"
+checksum = "effb0467f4d9b43be918a6e0ad419c539cd55dceef4c70000cb373701dc3d029"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -6444,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f1b72d43025037e2ef80598ddd2a7d2d7af7e592173fa49d787b405a314c24"
+checksum = "84e118557f0d4e863a243f2c91ffd4fce624c5afc42b6bd0e04e6f7cc767afd7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6463,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbfcca449d6ab4c922c4ea78647f0f9d0df0ddc29e23e2bf6c51bfd86abd97f"
+checksum = "4f369dabb59f4ec26bedb86f294f71b257e4d2e998a53693e45e711bc573627d"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6483,9 +6465,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05475c4590ac456090c430d5f8b0a3b66820048bd3b25fb273a992ea8c8e36e"
+checksum = "b2eefafbc018dc5a69cec5b1a9bbbc02fd3191464825e0bd5f899d407dfd03b9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6503,9 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191fe5efd59d6e68d36b15e5abf86a7169a3c1754e2a55f0ecd0555e8326eb05"
+checksum = "4b78dc5ba93d88d019eecb4d77f1ec95d8c288d9e9c4e039ab8a2dea039deea4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6524,9 +6506,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5669703e0437057c1054e73c10f8f2e256850905e318b0c235a587cbd89d616"
+checksum = "64984961a8667e8a16d2445fc98ac3229f9d01def0c1ae1e6f9ce859ec0fedbb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6600,9 +6582,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19d08a0f7f23bb70998456f04f0234548f6ee10507b0f7e74bf067e3eeeee2b"
+checksum = "242927ab508e5f1cb63aa851b7f5662f6886adb688c57458e05449c8ad0376dd"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6617,10 +6599,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-democracy"
-version = "34.0.0"
+name = "pallet-delegated-staking"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731fc36423b38b08b12dd3a3aeeaa1dda61a3207ee5ce24a209d964aede8a367"
+checksum = "72cfda2549b70198f2cdee30f8d72cae469a692f83b3072015062bc2dd6f473b"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-democracy"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517babb26eb2d61c21b13730fd8f48d5024233278581cc342e017f3436260aff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6637,9 +6634,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbfdd85dd5d5979067a47d4148f529da937ee017a846e98d4778764b3acfe43"
+checksum = "f9cae34d714e3410bcdd932ce0dc927997125e1eaa083dacdeb700439f22b67b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6661,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef65188f4db678f5b5098d74f67e35ea5a1c2eac3c57e628e8371bf013e5f7ff"
+checksum = "a5153f459dd839fceb81e1d1df9413cc55f83b55fa110485fdb05f442015fb57"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6676,9 +6673,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2306b2b9115109232e590604edc35395b33fbf7413a84bfdb24ae0e0b9e3585d"
+checksum = "b3aa78c1c9f42026482ce7f3c051e89ba26a7a9b52246af6e58ee2ce51eb29e3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6696,9 +6693,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202d0ffa99727097251e049039fc40a4bfba7f32d0f1c831614cc94f95d430bc"
+checksum = "aad27a480c5d4a4705808b8267d38540d5dfeee50d1e7d5a1684d7bbf98a4aa2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6716,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176f4dacb8f2e4f7cc807df18ced790d928c736b761b0eac5a855e9052efde40"
+checksum = "9cc1bf0bd43c8434b46af7de18f8863bfbbf56efcf8d340b238b511a52cfa03c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6740,9 +6737,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435fb7144dd4809744d6ed5bdb96da650f59456ee95eac886e8b63ce2288f041"
+checksum = "0ad181bf900fcea894911421496e05c4b2bc2dadea8c7d744af091a525af3a48"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6758,9 +6755,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb18daba67af89afab884392286b22c9da983d63adc2b4f42be42330fb645da8"
+checksum = "41a23e720204fde0302206016aaf1e095ff808ff1a434ec6507d87a40258bfe1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6779,9 +6776,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5474e1fe28673aa229805fa59bda1b5211a6cd5acd44d1ce8594761c5aa6a3"
+checksum = "639b5e46336d35cb888325da0294e54e558d26be45f767ff26ddfca42b709801"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6797,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958dd8feceeeacd1ae268eb0c2133887aea5f9883ae3410712f7b483b265c145"
+checksum = "4d48c79ce463ee54a9c6bf4ea82405499abc24999fa64f4a4e8b6336829d68c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6815,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f00efb1a89581346901a13f60c6d5be640dbfee516342f0b6b1ee679ed20354"
+checksum = "8913838f2059495cd9f0c3f9a402346b2f00287b077f344a1b84f850a164d084"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6836,9 +6833,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e1e6b63a3fdd57724c35b428c5cb13d2203108f643beb5870e72d0173af5c"
+checksum = "e836e2f38af303d9ae4c3b8ca512afe81279f2d6922223a8f571478740d09fb3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6855,9 +6852,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b5d37656066f03706dd9edf472785b531bb9dedec7d2a9c147cce2d4f30061"
+checksum = "2acdab77a60e7fbf76239ad530d00029fa7f9bc2194155c3356221aa76d19868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6872,9 +6869,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e4b82d3d48d0b0828acac780b2a383f1bb4fe2b33d945850d735571f8f0398"
+checksum = "6955efc279e63f4463ea29b45c81de013faa243e45a0155b0519df07d5e0a1fb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6889,9 +6886,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e13bbfb772e3530e4adb0ed000d5851c89c1e21949f199196d5aed4573d6c1"
+checksum = "7faf96228372dcaf4c01e53ba59248b59a4a9ec994f30bee373110900f34c7bc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6909,15 +6906,16 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c75bf20f34c61d8fa9e2eaac7e0196662c1f837193b980dd81ce8bf64b7f"
+checksum = "91b308c436d36e4159ec617e9e03e20a54aa4c2cd99729a411b969c1d9062392"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "pallet-bags-list",
+ "pallet-delegated-staking",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
@@ -6930,9 +6928,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436388be290be799b0eaebb3bf0faa71029d8326fa5726c578302cb1e8f78032"
+checksum = "57e14836c36af92c218a801d6dbd84460210f8af7820df400c5ffed6ae15006c"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6942,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8a7f971f79e0ced152437e2e2c3aa3d3230c347cb7042dac81bbf58518751e"
+checksum = "d2edc30910e938ef9df027aad650ea03644d0a33a604cec2267fce28951c0530"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6960,9 +6958,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87737faadaca16055217d7d4cace15fa47690a74e077ca3ca2269ac9d63928f5"
+checksum = "c605b2a3cf4eab08293ceb8f16a9352fcd71a27f0ab0dbdd8380946ab5800db6"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6985,9 +6983,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61797dcd19a4bc6367b031df02209182d410c00ce08a7d1d2d4ec00be54af4c"
+checksum = "d9ca55799e0693fafb28342892d5f71a52f95e2ca279f940faf8a7bbb4c8b835"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7004,9 +7002,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c464ba4684a0349c0266a50bb43b281cbed79ef2a217872796c433d293fa15"
+checksum = "e17c6fa28b38ef4cf33203709e3610c89aa8299900c7d0096bdec7b9e90ab2d3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7022,9 +7020,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e06086ea1c118f1603cba84c44a986b8132f54c51a710f72e0b4c9773bc3b5"
+checksum = "279b23df802b3edb41d04836cc2f97d59c358b3bd43d39b98fd1fe2e03204b87"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7038,9 +7036,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daeb4ce9471d306aab7a7f9b356643eb646df0be6306e241e499be442fe44da"
+checksum = "aac3413b3e5620c0b83bc32855ea16f0c9381fea96b85ffbe9490cb648815c96"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7058,9 +7056,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f925341a47c6c95f02e30af26d478014d8b6885193169e5ce0869b75eb5b05d8"
+checksum = "9fe5112bc7fe0282330e01a9c4fb58e42ed9030575eaf8479d54e3d6bd36f889"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7074,9 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a971ac06fcaa8b0e895c881e879e3c333f77bd79d1480fdffcc5b6e74750181"
+checksum = "7c969360bab41c9d50cd99755408690f23241424c3cc15935dd6c47206fc9c23"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7094,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84013a3fa1fb5553c840fc0b6d165448e0765b39ef7197b1ddf8b22f367b2f37"
+checksum = "059d0d7994b582126219f45410a9ef0c1db9655167ab4b84a9a16aafdb92ef1a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7110,9 +7108,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373a0c1386cf48e6e5f0e123fe67cc933e72e32d8fb05457ee7a48a96d53bef"
+checksum = "05840a0a1c517438d21873ad2279fea914eec836e1d76d15f29548a8ace6c707"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7129,9 +7127,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9170fef289c193773d94e2b6c799f09c97b199464902a8d220bfcd399a65d726"
+checksum = "7c77e7b0716fdf3cf8ecfcc872d583c972c4c9706842709a1112f26c51f701ae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7152,9 +7150,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea68db2e88494745b73e4e774326f7d39e0dbdf35f8b79e70d134f2d99fd0ecb"
+checksum = "42b450a525ea08dcdf4b3f33dce8796b2161c5c7917b99fba720d2fcd09b421b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7170,9 +7168,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e945ae7db25c0fa77c65882fb7138ce88a28fe08f151a539ea51a115b9595137"
+checksum = "236344aaf3ab6d088364aab2f284de04628bf1b7a187686347dbec7ecd0b8cc9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7189,9 +7187,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a563877abd32f7f3885d6437c196ba9adf1cfbc430afcc4059e6ede7ff354f38"
+checksum = "e8f63dce0732789c9222056a3292576b7843aa1c7eb5e7e0fcb158dbab8f4455"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7213,9 +7211,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-curve"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca5a4a423427d2c83af5fe07ab648c16b91e3782c3cc23316fe0bd96b4c794"
+checksum = "db5e6b1d8ee9d3f6894c5abd8c3e17737ed738c9854f87bfd16239741b7f4d5d"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7235,9 +7233,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc26b2f096e83fd919d8d6bb586963f2374b513a7c17fe356e67f585c88943b8"
+checksum = "3350ef1795b832f4adc464e88fb6d44827bd3f98701b0b0bbee495267b444a92"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7246,9 +7244,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204af00c1b72938db6a2d05b2dc6d1576f5957a9a9ec022ea6b5003f400f337c"
+checksum = "2fdd28b85f5c5beb7659a0dee158155b6114dcc747c139f247df944cca132df2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7264,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc1377f434c84a4afc3888dee27a01a0720c3fe77486f9dfb2e7310e6ad6b0b"
+checksum = "d15062b0caa6194e3ab13a10a500b2ed4b9d5915bf30dda18833e1c3bbbf6e85"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7281,9 +7279,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b43a57df90499460bf6645fd19390c8ae85bb225566c40e36cc8e2f4663b3f6"
+checksum = "34a42af51e32d3ea442e9aaabb935976e4154f89f3604bfb892a316e8d77c0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7302,9 +7300,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d451009c9a104acedb2b93aeb31096f93cfa4f39873f4b5a01d36bb3735c299"
+checksum = "9dae4a7f481f37cb839477dc1a2a8ce62ff962c25c48fbbad93631aa1c9fe0fa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7322,9 +7320,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373788faa2053bb2f6441921599ea06de81cdff0f96fcd1e6a2e021aa1296f72"
+checksum = "349e56fa9f8c4093d912f0654e37b57ae628ad4b4fea67d9f3373e5dfcab2bcc"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7339,9 +7337,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1019cbb539e864eabafc9cb327799c64ba885825cff822c654e4f394da1250e"
+checksum = "0e53aea571916432782288ba28ba2724a9564428c5b75a5b46dc13f633092708"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7356,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5362418d8a4ec0bf93773d79f5fc88d6533c5bb9939e495db7072d8db4dc1d"
+checksum = "331b2011bdf0ede2b607431360a94b7c3198f706bff63cd727c259e815f62389"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7369,9 +7367,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88e19f21e3ddec95df10b3f9411c801733f2e0a8185a7ed18ef17e98951fa2"
+checksum = "1317444c1dd38d7281db919b88331a9a76b483450a78f800d1cb76e21ce33563"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7389,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9f2e5a8595de607cfb062e0c115fadce3034c902b843f8f41636376a08d0a"
+checksum = "489431d3b751d07853119fd250145273ea050e84565b3435b5b19c6d3f622b56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7406,9 +7404,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8205beed2e075ef3d3651bb806d39fda894861e8e82807e42553d499d5e552f6"
+checksum = "79641f9c6720a5f1705a0b7464c13a6cf4c0a3d3c9db523ed73c345130bcaadd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7422,9 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeaf4774a0c69823a35560daea3642b98a5fc12432ce92efc0dd22b491e2dc7"
+checksum = "7a8196f8403117eab3042f49bec96b80290e9bef678017073f62b409e5311476"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7438,9 +7436,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5697c6ac29c8dd2e96d895ba6fe64b969fdcc5a5ab8cf6fa83240a519b2460"
+checksum = "870c71f937c78c722fc91a8f8fdf7bc0c74590eb01413eb17c5a72c405c9f134"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7463,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a95a496f4c2ce2c7b9318584f7e7c589efe456be161ad373144d8e356be6ac"
+checksum = "19da3779debfcbaecda285e8d240d0415cc7df7ff0b75bcaa227dbc2fa0cdb5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7556,6 +7554,7 @@ dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -7602,9 +7601,9 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a8836c0b86d76631b19fcc5daeb93c028c947a872fba0b1cd9621c0cf031be"
+checksum = "41525e5ddae2ae87949323fce5ba5e039ac5ceea2a76bcf34c6e794c111134f7"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -7941,9 +7940,9 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e286afe25b8f3cb10a0e31ad71ae9816b6357887ac88d4c1c80c275c775f6f9"
+checksum = "cd2f7de61c3e30845822cf071fced5302ce8d8dd9127c8cadb1aac1d6a431d50"
 dependencies = [
  "bitvec",
  "futures",
@@ -7962,9 +7961,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdfe06f87b9bff2586e079f33980115ad4d98fe984220340e8463b257efc47e"
+checksum = "9ddd8c20cba24cc94df433357e90f542cfdd1d1835d6a3859dc379b7eeb7cb43"
 dependencies = [
  "always-assert",
  "futures",
@@ -7979,9 +7978,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3abdb4827ede5b83e8eb196589d14e55ba004fd039bb37270c53ca4988d6876"
+checksum = "4eca33cf1901a090ac35ffc991e6394cb8ba5020234d6e32a800f5051ce629b9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7994,6 +7993,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
+ "sc-network",
  "schnellru",
  "sp-core",
  "sp-keystore",
@@ -8003,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf9cefe5cd848bc70094e4ccced9a080d8e416eafbfb8347c7d04477263668"
+checksum = "1817e10f78d6c8dafc63f25cc5e15e93cad4a1b861f8b8634fa6244441624582"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8037,9 +8037,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f8ad5726f1934ed4b20608ff9839cf0c4c99403b0b661376c99c06a2156737"
+checksum = "ecebd0f0e2dc1bcb521245c2ff2b76854407691cf782586eadd4a868f526aab9"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8066,9 +8066,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc243c5ec6656333c0a2e8e218bea936b4d8d7566902c9825539e8058e29d77"
+checksum = "4440aad91c57574efb4a04e095570111d31c3a24d0fceb203973585243d74ae8"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8089,9 +8089,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fed6798f76290be654149afd585cfef09bf796990b68c79d7ee5e5110a04d15"
+checksum = "17c72ee63bcf920f963cd7ac066759b0b649350c8ab3781a85a6aac87b1488f2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8102,9 +8102,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8948a0740287f37c431c0d1741f9548ea20e2be2e8ddca00221d463a1ea0de9"
+checksum = "afeea4e15a232d97e73be9acddded88df0749e583b6bc80ba5400e6f9a8ea912"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8128,9 +8128,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e898aa343f565e65b48c99e30ab776a2bdcc7088b048942c09594f3e3776e4"
+checksum = "6a39a54a269817e09d602b4e9c527905f9e367ff7c6337b1b3e1e048515f6b59"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -8143,9 +8143,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824bf17499380d6038106160125c14977f771e5889f85bee74183c6cb76be30a"
+checksum = "45a5a4f4ef27ac178251ab064a2545e9e303e8fd1b1264b6df461e425b054065"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8166,9 +8166,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b415a638142f6d0a1e2adee0928fa0ec6a3a195dce4b90e2fd8985fcd11629ca"
+checksum = "ebc32407362fa5f8444067bf6b7942ae5f10dfc1a4bde056181a085381d9d60c"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8190,9 +8190,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2b311707daf7f3183c62fc1c7758be4ae566b5a4d9320dbefe938d31a0831a"
+checksum = "c9d84116b4220e2f8f8c5c3933dc4a21c3c8751079b3d89c605121b44fd201e8"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8209,9 +8209,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db9fcf15099e8ecd8e23f636302d137d73dba14236e959fb4ab091cfec3ead4"
+checksum = "a9e37706970e30cd57d2aa9d0ab57a6c25474c8bae0a2ef7b7dc4dc262ccd146"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -8243,9 +8243,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea8680f339aecffaf2238a5f8e1bc9689cf5d67b7071760707aedfc4eaa3160"
+checksum = "503d0c01f6b0f2ed31bd531ef9763719df4355b63d19e489a796912743afd423"
 dependencies = [
  "bitvec",
  "futures",
@@ -8266,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd7fb51c8affa18d0f5db31b682678d501451584c5ceddf686bad9dffc5950f"
+checksum = "01e5505fabfb2b9dcebc05f596c249b57a2b4dcb9d65d5655406fb1693f3f5db"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8287,9 +8287,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5081cfead44128c0a6628d99437c19f649bc55f8dd2ed59c09874d7622b2d198"
+checksum = "2af24edddafe308811f73dbd5a97b26a8ceb9a4ee1da5a6ae8487250b1930b0a"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -8303,9 +8303,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81220717085bd60549c8c5e4adfc4bea56e224f825f03f8660b953bab79fd1b0"
+checksum = "9d16611223b95f59b3b3395b97807035114b7b3f4fc91cdea893981534e3a0bb"
 dependencies = [
  "async-trait",
  "futures",
@@ -8325,9 +8325,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417bc195bb50f5c1b5db5d8d04783b81e8e54e9c82447d9880f58a59670f8db2"
+checksum = "09318b543a6e7a1a7309e1841331e8a2d9f0c7ef2a2929efb75f296492cff36b"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8340,9 +8340,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9373236b5d0b50c506204f456e32c13a1fda71a0f02ba6b6228c1fe07812e0d"
+checksum = "358fd0d04fa636c94b1fdead690d2049e580843cfd623a913297d791d0d9db23"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8358,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a854e6e2d8b5570ac2ec3af9f0b39fff70082c7b26df4621460a3f563c06f2a6"
+checksum = "ef762a62e1c3894b01c7103710bb17fb8b4bb65444011d5e9e62a78933874d47"
 dependencies = [
  "fatality",
  "futures",
@@ -8378,9 +8378,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4546a35725c881bae40b125237c72fa3ba9398bd7d59cdfc594d018a3d86cfb6"
+checksum = "0ad8e655826a7a7f437e53331c6e1959930307c0ec9c174f100cb1a28f95267d"
 dependencies = [
  "async-trait",
  "futures",
@@ -8396,9 +8396,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1bb5aa18ecf4e7102b0aca1bf5992ca09b18969c5582852ed81d088a5535dc"
+checksum = "3899b61909cc0578ee72f73d67fca81865a2c8459df0a440df07a7203757f587"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8414,9 +8414,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b087b67faa4ad089f1979fe1a510afe856a9c5a356c78c9f02ba3def02d1d51"
+checksum = "16da0e6b5778ac22802fb30c83e6a4e861f8386c8104a63ae0ed15cc959497c4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8433,9 +8433,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08225e89f86d7ac77a58e75e2f42f25487575717673d940570dc02b28423047a"
+checksum = "147d797f376100bfb83dfff60cd86805e1ccbd5a6d3db76bc2adc73ce95c1818"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -8463,9 +8463,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4d5b001b0e079ec3043103543d52a6c561ea58afd7e4a552c2b5f82219d99"
+checksum = "39152f2c3b313cd901f3c9554a1622b4a2deacd539af3a7bfae6fbb94839ad9c"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8480,9 +8480,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da16a57610c19669a557bfbad8619dde57d72392b6ee77ceeae15f6b6e6bc327"
+checksum = "d8ab48ae1d313a9053153ad66cd9f80f26731feb54a7f03208d60076f1b3e188"
 dependencies = [
  "cpu-time",
  "futures",
@@ -8507,9 +8507,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb515d39f8fd15b6ea0377feb6c891fe76edcc4845958e1ae0595ae5b4239db2"
+checksum = "9c19882aa444012ea6c610b473131b0f15ef12e3dd2f897125ef57b38fdc8acc"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8523,9 +8523,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a596644f8861f8a298ca06bd489abb359a42dc4314bd7b9cc9bf8c53f066e"
+checksum = "fd5e646fedc21914c77e682e8ec93f6d3440887fb076cd6b7b267f9bc193c025"
 dependencies = [
  "lazy_static",
  "log",
@@ -8535,7 +8535,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sp-core",
  "thiserror",
  "tokio",
@@ -8543,9 +8543,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b758d586de1b1fb1a83d008be8f1930b131cf3b6959f9a1d24021a2906b9e9b"
+checksum = "32a808897db8b9c36f89f148febcbdb0a02b06f8938752113d8972f3a836d518"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -8563,9 +8563,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da2f608ea60ec601aa33863637de01f325235eaaa0c6193eee9aea27755b5a9"
+checksum = "9e745a85464f42b58fc645c020cbd78baa083e0ebf1af2b4f499eb466e19e405"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8581,7 +8581,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sp-runtime",
  "strum 0.26.2",
  "thiserror",
@@ -8590,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39956470139586e4b10b9e913dc7ae26005a45ba1c4e98feade1d9449e4a25ed"
+checksum = "779833f70a1563ed042d3c6b831a45c5ea0f80caa8f4ede487f7bee3130168fb"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8614,9 +8614,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a560c09498c1b311e96896e6ed952308d2972577035ac643ed57d070956877b"
+checksum = "1496f6759e964605b18d744babe6b4c430f4c0f4580663179f85976deffc5e39"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8625,13 +8625,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f94a624078ec1714b468f57dbc1c8730ec24a4f3241d774c43b5c501b61ed66"
+checksum = "a3ec11aa0eec2adede73aa14f0ebeb2794180f1b5322f0e75bfd1215d3f29b68"
 dependencies = [
  "async-trait",
  "bitvec",
  "derive_more",
+ "fatality",
  "futures",
  "orchestra",
  "polkadot-node-jaeger",
@@ -8641,7 +8642,7 @@ dependencies = [
  "polkadot-statement-table",
  "sc-client-api",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
  "sp-api",
@@ -8655,9 +8656,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e7920f7ae2e610b615ecd764c43c356f38492cc3236520e83537cc9e21141f"
+checksum = "aaedb65dccd2fa8dc6c060fc93d11c73794f0b3ed3cbae20bd27159e16345785"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8670,6 +8671,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
+ "polkadot-erasure-coding",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -8691,9 +8693,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b741afa899f746735fe67e62cbfebc5168b95bcfbaad75f27b01a6e6a5ff8a"
+checksum = "4004808b1cdfac76b38d4af1331f63a1ea4dabc64ce95526d2d2db2a637017cf"
 dependencies = [
  "async-trait",
  "futures",
@@ -8714,9 +8716,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cbf31ea1fbf6e8f2db854813269abfca3a7eb5e2c4b1493345a29b2a01abd5"
+checksum = "f61070d0ff28f596890def0e0d03c231860796130b2a43e293106fa86a50c9a9"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8732,9 +8734,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7621b5ba096c04bf81c9e310c6cb327c365de5a68993aea380a1a897f3b0836"
+checksum = "5a4879609f4340138930c3c7313256941104a3ff6f7ecb2569d15223da9b35b2"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8760,9 +8762,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867202b559a9328f8f314d289a5e326f903a758e6b00e1fc1f7d60cf2941115"
+checksum = "a9e0ff61f56a02a50d5d894b966e2224c67b9d2b7e38043832480089a7ca11fd"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8782,10 +8784,12 @@ dependencies = [
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
  "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
+ "sp-consensus-beefy",
  "sp-keystore",
  "sp-runtime",
  "substrate-frame-rpc-system",
@@ -8794,9 +8798,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1215fb26c995f9a2ac815c28498e90347373d868f9e07bb8f180ea607a678108"
+checksum = "929499dd53b664110a787bd700030c0d5aa55ff5732556007e052711920933e8"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8846,9 +8850,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54a84f56cf84685008ef66eb85d7ce6d87511b9c21a38ab214bbdd2917ae93f"
+checksum = "17496ddf5f7bc75db80d8b5c8183a1fbc64d984c39238055c67bd45469d97e37"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -8860,9 +8864,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69158a812736547a76333b97da33fdcc2830e6f8c613d8e89541845e294537a6"
+checksum = "2502de64c7fea2a931712c3e0eb0830ed0af753115472c7ccb2b74c4eba61c65"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -8910,14 +8914,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7113642afd582260667a50d550378310fb68be3991316eda3ab3c82a37ccc"
+checksum = "2d0a5439b90eedd716501595b789435d677e7f0aae24ee4c20081572bd4fa56a"
 dependencies = [
  "async-trait",
  "bitvec",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -9031,9 +9036,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246d41a17db83e3dce3d0b451887fb22991aceda9c78fe092f54fa98b6296178"
+checksum = "4a14f12405ecfc8feab17a38756e3668619cd0df4613211c23e0258c24009c91"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -9055,9 +9060,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9b54c9dbd043cdf485a5e0c2718892fe5c64e6114e2d1ce578fb33605b7c2e"
+checksum = "947e9e3c8f71b9678f39a01f371a808b574823967dd9da187e6f886f5f08691c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9232,6 +9237,16 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
 ]
 
 [[package]]
@@ -9458,7 +9473,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -9491,7 +9506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -9989,14 +10004,15 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f09353883a98e00d2d8e1e834afa8f8d4fe56f00179843c9b88226db38577ef"
+checksum = "79fc69d149aa86315ff2338311308a6ae31734f179ca0f859cddd5df263422f2"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -10090,9 +10106,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07e4b8066110a58d9e6290b5f5ff189684495a0ae8c4b07eca5f5b8d1353595"
+checksum = "22bd236a3170000b05950c1bf5e91ae99d4f99b1186553a21756f0edacc721a9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -10387,9 +10403,9 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f01218e73ea57916be5f08987995ac802d6f4ede4ea5ce0242e468c590e4e2"
+checksum = "b975ee3a95eaacb611e7b415737a7fa2db4d8ad7b880cc1b97371b04e95c7903"
 dependencies = [
  "log",
  "sp-core",
@@ -10399,9 +10415,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "218036a165861e60bef6f585c20fd2eb89286056320ffb67c86fd935e80bc9b6"
+checksum = "e9aed092c3af161b8e5000e3152a560f8ddec740c7827084a201c8346e85d79d"
 dependencies = [
  "async-trait",
  "futures",
@@ -10418,7 +10434,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
@@ -10431,9 +10447,9 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca210a343d5ad2f44846d61e43acc5aca356470f5524b72354653f7270dbf6c6"
+checksum = "cdeb3ce0b4f25daa0d3026c2d9f6a21654a798bc5d4dc931272b9b39533b9b09"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10454,9 +10470,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c1a029e5f794a859bbda434bb311660fe195106e5ec6147e460bb9dffb3baf"
+checksum = "d6345fb862e10aaa7d88d6689a7c247448c40ae465253c83566dc76a17ec1426"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10470,9 +10486,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b161ea70cfb2340f8fdd288fca185a588e689cf1f07d6439e45541f4b5fe8b"
+checksum = "ae230af4bbf2f518da9fd2c710e2b1945011d993017ede3e0f816c6d825bb225"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10498,9 +10514,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e80fbdaea194762d4b4b0eec389037c25ad102676203b42d684774ae3019b8"
+checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -10510,9 +10526,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25220d6f9120bb49255e6806586eae22c999242fcfc61c3fd797a36180661ee9"
+checksum = "f9a727a3ea99b22dd275fa49b05bcf2db195d444f9c3ca1c4388fd2334425f70"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -10552,9 +10568,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6812c65d63c576e0f61d063fb0794420ce6312c5de9072269643ac1355537ea9"
+checksum = "5b1c4e71765e679439a7e5af3f92ad4ebdccc36c02ef485de604bb3dc5d98267"
 dependencies = [
  "fnv",
  "futures",
@@ -10580,9 +10596,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf275ceb82f4a508c0553df6a0ebc8cbfc6b03fe894ab509cdc4a0aa64d5864"
+checksum = "2e3c685871877f39df000ec446f65fc8d502a7cecfc437cdac59866349642dc3"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10607,18 +10623,18 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8599723d670725369aca94e0bc76863c14d7a68ee1ba82d0c039359f92b200e"
+checksum = "5d7149e17ec363316391119f614ffb0da96284f4ed3aa1d67560687f627605b6"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parking_lot 0.12.3",
  "sc-client-api",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-utils",
  "serde",
  "sp-api",
@@ -10633,9 +10649,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b312ad1c846f78dbfc1f755bd7a0cd61910214b821cf7e0aebce96d4b1b3a0b8"
+checksum = "ebdedb86c3939254d7b6a01352f1aef450aaab17b2886a8d233f79e753d77fda"
 dependencies = [
  "async-trait",
  "futures",
@@ -10663,9 +10679,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e676a852225485d7f89ed2bd985b14d371964e3f682fb52b32b3d10dced3280"
+checksum = "da9ef4db80306f8dca3ec37e05d4b7ab5bf4c5fe5a9cdc6a12ec7b95f01710d0"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10700,9 +10716,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434d7c76dee1c4b0d1594eb517c6f4b923b08b81c3ae890fee6411e70451d73"
+checksum = "4336200d7a52573c7e4722b808763ee27db46353807b32300f59fe8114fa43c2"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10723,9 +10739,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4800134697fa5913275969e684ce709d0d73b3cb9d28824b07c4bf2e86bf204c"
+checksum = "893b263b88ffa7c92e23bf14132c132b932fb028fe411eacf43f69025f563417"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10740,7 +10756,7 @@ dependencies = [
  "sc-network",
  "sc-network-gossip",
  "sc-network-sync",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-utils",
  "sp-api",
  "sp-application-crypto",
@@ -10760,9 +10776,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eec266bc09311db98c10dde271ceef159657d65280df6b2b69c36ef32e3c817"
+checksum = "72636eba4c9565a1f1ccd9f18750c15d58122d972aec10c0559e157b9ab9ace6"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10772,6 +10788,7 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
+ "sp-application-crypto",
  "sp-consensus-beefy",
  "sp-core",
  "sp-runtime",
@@ -10780,9 +10797,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678180c64ce942dd6c38faae95dafdb097b95dbc6bccb2dfb125646114432e"
+checksum = "d977b172eb79c6ae78179ef157032a899da449a2cfa093019c03a5e04f8f48a6"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10794,9 +10811,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c5b758a15d8addfd4874fa370a4dd14a4e3e5911dc663da6f384f4d8090fd"
+checksum = "3380570b0c27d2c26dd16a3c73ea99e8b87c0a91b4d7e1e7332dd501d0250d95"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -10818,7 +10835,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -10839,9 +10856,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff06659eb842ea2b090a3dc95dd39cddaf00b670c7938f2dec94d1fc30d84c5c"
+checksum = "9d7b01772a9d98bc263561fe89b87a2461dedd0d3aa38f05847039ff256020f3"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10860,9 +10877,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c923c07005b88b62c6e63b2e08c9a45ac707ef90c61ff5f7f193e548ad37af"
+checksum = "75e3bfe4d5d4c031e747436291356b7c8bb8a5885a0e3b3a4916aa7eb359d8b2"
 dependencies = [
  "async-trait",
  "futures",
@@ -10884,9 +10901,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321e9431a3d5c95514b1ba775dd425efd4b18bd79dfdb6d8e397f0c96d6831e9"
+checksum = "39f5767bf6a6bad29365d6d08fcf940ee453d31457ed034cf14f0392877daafd"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -10908,9 +10925,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad16187c613f81feab35f0d6c12c15c1d88eea0794c886b5dca3495d26746de"
+checksum = "0c3b703a33dcb7cddf19176fdf12294b9a6408125836b0f4afee3e6969e7f190"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -10922,9 +10939,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db336a08ea53b6a89972a6ad6586e664c15db2add9d1cfb508afc768de387304"
+checksum = "26fe58d9cacfab73e5595fa84b80f7bd03efebe54a0574daaeb221a1d1f7ab80"
 dependencies = [
  "log",
  "polkavm",
@@ -10934,9 +10951,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b97b324b2737447b7b208e913fef4988d5c38ecc21f57c3dd33e3f1e1e3bb08"
+checksum = "8cd498f2f77ec1f861c30804f5bfd796d4afcc8ce44ea1f11bfbe2847551d161"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10953,9 +10970,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ddef3aa096a40f84599c90c4045ece585fcc06ef64d657fe88f8464f3d7106"
+checksum = "ec34fec99cdbc434918f9135c996af1f55e4c65d4247b7ecfeae47e957285588"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10971,9 +10988,9 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076394555f3325fbe66d5e1216eb210c00f877910107a02d3997afbad9b23af6"
+checksum = "267c8cfaceaeecb25484bad8668c17036016e46053a23509d44486474dbf44d3"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -10986,9 +11003,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3756952a98f6e8aab2715e15d8af73191d736c1c3e35c05a7bac2033c33949"
+checksum = "f7f295f4c06dfad60e8a5755a3866bb756bcd8208fa2f4d370c92fe2ec0de07c"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -11003,7 +11020,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "sc-client-api",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus",
@@ -11016,9 +11033,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd70d3fb1d9ff0165ea9c23cb4f6963e8fe0d65847ccae3fc4c7fc92bd02543"
+checksum = "6dc1b9eea5954cd4cec2a13a264f5c54d2f43e155b4f1065eaf285fa602fce1c"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11033,9 +11050,9 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
- "litep2p 0.4.0-rc.1",
+ "litep2p",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11046,7 +11063,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-utils",
  "schnellru",
  "serde",
@@ -11068,9 +11085,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b9a2597285d5bc18b871d5bd69e99c724caffddee22b002b27e7e89a37e6a9"
+checksum = "8a86e8a1a517986fd00fd2c963347f5f459241c2ae4e84083ca34b2078f79651"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -11079,7 +11096,7 @@ dependencies = [
  "parity-scale-codec",
  "prost-build 0.12.6",
  "sc-consensus",
- "sc-network-types 0.10.0",
+ "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-runtime",
@@ -11087,9 +11104,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962b37f9939ea0d678219cd4beae5b604b2ee2836e670c14fe3d347e21d57790"
+checksum = "17d8d4b7cc4eb58e9f1e73eb6ba84de8bb0101f14d5c688ae7bd5ff0535ed282"
 dependencies = [
  "ahash",
  "futures",
@@ -11099,7 +11116,7 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "schnellru",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -11108,9 +11125,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d0c7dabde3a1a4a49b383503e4589bb3373044fc8513dbf849547f7d450af4"
+checksum = "404aeef08ca7be7c0980cec7e633b3fbc8e325fb6ec7817b38d1b4fa9f2636d2"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11121,7 +11138,7 @@ dependencies = [
  "prost-build 0.12.6",
  "sc-client-api",
  "sc-network",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
@@ -11130,9 +11147,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61620bf88ffa4e67dfcb245569c293a7a3815b9f8d37f93fa9944bddda68ee9d"
+checksum = "4599c3b68457fd150491074de9a3999030953bdc84a79780cb32e6a74c875be8"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11142,7 +11159,7 @@ dependencies = [
  "futures-timer",
  "libp2p",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build 0.12.6",
@@ -11150,7 +11167,7 @@ dependencies = [
  "sc-consensus",
  "sc-network",
  "sc-network-common",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -11168,9 +11185,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee98c3909782dc7aac343b41ea8d8d2525d4def168c005bb1fb37b4e8a4ecc1"
+checksum = "e14f67c5914e801e660a6aca7e0055723530f694b98ef8b30df142c918fcb5a1"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11180,7 +11197,7 @@ dependencies = [
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-utils",
  "sp-consensus",
  "sp-runtime",
@@ -11189,39 +11206,26 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b473a65393f65579019e4280cc116848439985c62724db8402bbfa7da462d1"
-dependencies = [
- "bs58 0.4.0",
- "libp2p-identity",
- "litep2p 0.3.0",
- "multiaddr",
- "multihash 0.17.0",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "sc-network-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78a8ca5b07ab6ac40dd21e7724453a42c186ba546406c198aa8c6f31e4e6f2d"
+checksum = "efe67b8d4050c438331b82969d40e4a1e665d0dfd9eb0a5e949c02b925b5484d"
 dependencies = [
  "bs58 0.5.1",
+ "ed25519-dalek 2.1.1",
  "libp2p-identity",
- "litep2p 0.4.0-rc.1",
+ "litep2p",
  "multiaddr",
  "multihash 0.17.0",
  "rand 0.8.5",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9230e5537f553bb9dcaa5f782acf0e2de6ba7658fe5fc9b7844c0a675c69946a"
+checksum = "aa5e3ad7b5bebfa1a48f77cf6bb415bac4c7642d645d69ab4bd4b5da85c74ddb"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -11240,7 +11244,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-common",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
@@ -11265,9 +11269,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b626348dad6f3eeda3595dd1331dc3f04468e075d61ec53599bcb084f93b41"
+checksum = "6cbee238062a62d441cd98694a0a9135c17bad13d8ccb3f54eba917cf14482e3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11298,9 +11302,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9e316c596ddc56f452faa325e0981aa58389cbbb908f7f13aad00a71efbb15"
+checksum = "5e383ce9ec80c14694256a55a4e70b9929d4559d9b1fc5decf2d344c39d94208"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11340,9 +11344,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b7a2a25ae6329560d7b5b75f0af319629fd0cfbdc23663ce6aa20d439a4439"
+checksum = "7f6e14f8562b86f9e1a54fa287b2d26164c1b84871d51719a78976ec747e3e49"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11373,9 +11377,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e97eceb358fc3755d5675591f707cb978b1032005e8c32bee43da88d58a7a5e"
+checksum = "5e6b4822a49f75485f8d95c34818eef4ddd8a62e0c131f72fd7a680bf1ec2ef5"
 dependencies = [
  "async-trait",
  "directories",
@@ -11400,7 +11404,7 @@ dependencies = [
  "sc-network-light",
  "sc-network-sync",
  "sc-network-transactions",
- "sc-network-types 0.11.0",
+ "sc-network-types",
  "sc-rpc",
  "sc-rpc-server",
  "sc-rpc-spec-v2",
@@ -11438,9 +11442,9 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863b63626c6602167953125b7b0430939b968d6ba13bd795998ac66d3ce124c9"
+checksum = "f689d0b97c1bbdb2ca31b5f202bda195947f85c7fef990651cad202b99de896b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11450,9 +11454,9 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e69686e7593e6d90432e5476b85219cf8636f0e9941d84d30cf80b2995cc632"
+checksum = "1d117c3945c524b9c0e30966359895f5ad551c2cd4ccbb677b53917fbad5039a"
 dependencies = [
  "clap",
  "fs4",
@@ -11464,9 +11468,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2de2ec69614f29a2f1a8f9dd92f296a6c8990d156a6737f42744b9462311b15"
+checksum = "b92099c0a7713f3de81fcf353f0fa0cff8382c1fc7aa122b90df317d276cb113"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11484,9 +11488,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a48d1c042e09d19cb4812f5d7b76781095b8832e8ffe07b6679ee524ebbf782"
+checksum = "04295dc630eddd421eef0e4148b00b66cd85fdfba900916af140bc84dcbcfeaa"
 dependencies = [
  "derive_more",
  "futures",
@@ -11506,9 +11510,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1186331805100037171f2069a3c3b4a9c8ec01144863626c3276b999960af67"
+checksum = "85ee91de6648ca949b8080fe8a787c1bf2d66311fec78fba52136959e0b9719c"
 dependencies = [
  "chrono",
  "futures",
@@ -11527,9 +11531,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cfe597106614e64cada52406df9d5e6c802c3982ef367d83ff240a0b59e7c4"
+checksum = "61151f2d6b7ce3d7174484414dbc4e2f64b05a144c8f0a59ea02284e6c748a19"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11570,9 +11574,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bc0d2515ec772b2391e3e641766c13d1a9b66fd60a7f68a4b82be5ae33801c"
+checksum = "800e35d0d2f2b8e17170ec961d58756fe7891026b19d889be388b9585cb12f90"
 dependencies = [
  "async-trait",
  "futures",
@@ -11598,9 +11602,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39dfa40c94e3965547d4fa0e7f7bc491b02bd7891cfd226a5fa8451c707f18a4"
+checksum = "b3de6f60df6706970061e225e87d77aab9a764b258fe151b896a700419bc6b9d"
 dependencies = [
  "async-trait",
  "futures",
@@ -11630,6 +11634,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11654,6 +11681,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -11734,9 +11767,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f64cef148d3295c730c3cb340b0b252a4d570b1c7d4bf0808f88540b0a888bc"
+checksum = "b6220f78bb44c15f326b0596113305f6101097a18755d53727a575c97e09fb24"
 dependencies = [
  "bytes",
  "crc",
@@ -12074,9 +12107,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d7d232571cc6f04fee2fa2486dddc222ed2a043fbf9ad942fb7b98a87f4b2d"
+checksum = "a4d67aa9b1ccfd746c8529754c4ce06445b1d48e189567402ef856340a3a6b14"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12269,9 +12302,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84f09c4b928e814e07dede0ece91f1f6eae1bff946a0e5e4a76bed19a095f1"
+checksum = "b7e43fbf034e9dbaa8ffc6a238a22808777eb38c580f66fc6736d8511631789e"
 dependencies = [
  "hash-db",
  "log",
@@ -12292,9 +12325,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213a4bec1b18bd0750e7b81d11d8276c24f68b53cde83950b00b178ecc9ab24a"
+checksum = "c9aadf9e97e694f0e343978aa632938c5de309cbcc8afed4136cb71596737278"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -12307,9 +12340,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296282f718f15d4d812664415942665302a484d3495cf8d2e2ab3192b32d2c73"
+checksum = "0d96d1fc0f1c741bbcbd0dd5470eff7b66f011708cc1942b088ebf0d4efb3d93"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12337,9 +12370,9 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c06b0d26bcc9b5db298c4e270fdff286411912af51bc0d9ef7d04f139ee3146"
+checksum = "6a4a1e45abc3277f18484ee0b0f9808e4206eb696ad38500c892c72f33480d69"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12350,9 +12383,9 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329e1cfb98f113d91d0db80a6e984cbb7e990f03ef599a8dc356723a47d40509"
+checksum = "2cf199dc4f9f77abd3fd91c409759118159ce6ffcd8bc90b229b684ccc8c981f"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12361,9 +12394,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "34.0.0"
+version = "35.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6900a6681cfa8f817e14426e5b5daa7fb101431917182361c995e62f98ed0b09"
+checksum = "f27eb18b6ddf7d663f4886f7edba3eb73bd102d68cf10802c1f862e3b3db32ab"
 dependencies = [
  "futures",
  "log",
@@ -12380,9 +12413,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7effe855bb4ca3a24273d10802d6b536d618936fee9dfbcbbdae19ed1bb042e"
+checksum = "ab094e8a7e9e5c7f05f8d90592aa1d1cf9b3f547d0dd401daff7ed98af942e12"
 dependencies = [
  "async-trait",
  "futures",
@@ -12396,9 +12429,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464c5ec1ffcf83739b8ff7c8ecffdb95766d6be0c30e324cd76b22180d3d6f11"
+checksum = "05ebb90bf00f331b898eb729a1f707251846c1d5582d7467f083884799a69b89"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12413,9 +12446,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec35149556b61c81c12b57ef90ff3d382a2b151f28df698e053a9f68f7aeb3e"
+checksum = "3aa2de4c7100a3279658d8dd4affd8f92487528deae5cb4b40322717b9175ed5"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12432,9 +12465,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f70758400b17ea3bd2788108434cc726a47a057b50acf5d095b02872e52797"
+checksum = "b277bc109da8e1c3768d3a046e1cd1ab687aabac821c976c5f510deb6f0bc8d3"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -12453,9 +12486,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7deefa0a09cb191c0cb7a7aa8603414283f9aaa3a0fbc94fb68ff9a858f6fab2"
+checksum = "21dd06bf366c60f69411668b26d6ab3c55120aa6d423e6af0373ec23d8957300"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12471,9 +12504,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063ccdb38545602e45205e6b186e3d47508912c9b785321f907201564697f1c0"
+checksum = "c8ca60d713f8ddb03bbebcc755d5e6463fdc0b6259fabfc4221b20a5f1e428fd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12483,9 +12516,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "33.0.1"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3368e32f6fda6e20b8af51f94308d033ab70a021e87f6abbd3fed5aca942b745"
+checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -12576,9 +12609,9 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33abaec4be69b1613796bbf430decbbcaaf978756379e2016e683a4d6379cd02"
+checksum = "a904407d61cb94228c71b55a9d3708e9d6558991f9e83bd42bd91df37a159d30"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12587,9 +12620,9 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb26e3653f6a2feac2bcb2749b5fb080e4211b882cafbdba86e4304c03c72c8"
+checksum = "fcd065854d96fd81521c103d0aaa287d4f08b9b15c9fae2a3bfb208b0812bf44"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12600,9 +12633,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6766db70e0c371d43bfbf7a8950d2cb10cff6b76c8a2c5bd1336e7566b46a0cf"
+checksum = "53407ba38ec22ca4a16381722c4bd0b559a0428bc1713079b0d5163ada63186a"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12614,9 +12647,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a31ce27358b73656a09b4933f09a700019d63afa15ede966f7c9893c1d4db5"
+checksum = "5036cad2e48d41f5caf6785226c8be1a7db15bec14a9fd7aa6cca84f34cf689f"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.1.1",
@@ -12641,9 +12674,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a24506e9e7c4d66e3b4d9c45e35009b59d3cc545481224bf1e85146d2426ec"
+checksum = "b03536e1ff3ec2bd8181eeaa26c0d682ebdcbd01548a055cf591077188b8c3f0"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -12652,9 +12685,9 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a909528663a80829b95d582a20dd4c9acd6e575650dee2bcaf56f4740b305e"
+checksum = "0248b4d784cb4a01472276928977121fa39d977a5bb24793b6b15e64b046df42"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12685,9 +12718,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ac523987a20ae4df607dcf1b7c7728b1f7b77f016f27413203e584d22ffde3"
+checksum = "2f65a570519da820ce3dc35053497a65f9fbd3f5a7dc81fa03078ca263e9311e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12697,9 +12730,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "32.0.1"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4370db10d0f7b670ba33d1a69dc2a09a1734d45b3d4edea78328ff9edf5d31"
+checksum = "47412a2d2e988430d5f59d7fec1473f229e1ef5ce24c1ea4f601b4b3679cac52"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12715,9 +12748,9 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643b08058800b3a1bd0ad7155291e75e14c936974837c074ae3cfdc5d1fa294e"
+checksum = "0b0c51a7b60cd663f2661e6949069eb316b092f22c239691d5272a4d0cfca0fb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12729,9 +12762,9 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e7bdda614cb69c087d89d598ac4850e567be09f3de8d510b57147c111d5ce1"
+checksum = "cbe721c367760bddf10fcfa24fb48edd64c442f71db971f043c8ac73f51aa6e9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12751,9 +12784,9 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7b352143ee888fc624adff978e32b2ee6cf81d659907190107e1c86e205eeb"
+checksum = "45458f0955870a92b3969098d4f1f4e9b55b4282d9f1dc112a51bb5bb6584900"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12762,9 +12795,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2a6148bf0ba74999ecfea9b4c1ade544f0663e0baba19630bb7761b2142b19"
+checksum = "89ef409c414546b655ec1e94aaea178e4a97e21284a91b24c762aebf836d3b49"
 dependencies = [
  "docify",
  "either",
@@ -12788,9 +12821,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647db5e1dc481686628b41554e832df6ab400c4b43a6a54e54d3b0a71ca404aa"
+checksum = "985eb981f40c689c6a0012c937b68ed58dabb4341d06f2dfe4dfd5ed72fa4017"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12822,9 +12855,9 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601e0203c52ac7c1122ad316ae4e5cc355fdf1d69ef5b6c4aa30f7a17921fad9"
+checksum = "4daf2e40ffc7e7e8de08efb860eb9534faf614a49c53dc282f430faedb4aed13"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12837,9 +12870,9 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817c02b55a84c0fac32fdd8b3f0b959888bad0726009ed62433f4046f4b4b752"
+checksum = "0a0b7abfe66c07a3b6eb99e1286dfa9b6f3b057b0e986e7da2ccbf707f6c781a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12851,9 +12884,9 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6ac196ea92c4d0613c071e1a050765dbfa30107a990224a4aba02c7dbcd063"
+checksum = "211e528aa6e902261a343f7b40840aa3d66fe4ad3aadbd04a035f10baf96dbc5"
 dependencies = [
  "hash-db",
  "log",
@@ -12872,9 +12905,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f857a29733a0240105d05f6d36bc7d760d814c22c6b12997f2d153236bfc8220"
+checksum = "b03aa86b1b46549889d32348bc85a8135c725665115567507231a6d85712aaac"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -12916,9 +12949,9 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d48d9246310340b11dc4f4c119fe93975c7c0c325637693da8c755d028fce19"
+checksum = "78becf144a76f6fd108dfe94a90e20a185b38c0b310dc5482328196143c8266b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12941,9 +12974,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14de2a91e5a2bebaf47993644643c92564cafc55d55e1c854f6637ee62c90b4b"
+checksum = "a3c9d1604aadc15b70e95f4388d0b1aa380215520b7ddfd372531a6d8262269c"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12951,9 +12984,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeca8215fb05fd67b4d72e39d8e3f0ed9a3cc86c95da95bc856ebc4c23f95c8f"
+checksum = "5b5a891cb913015bb99401e372255193cc3848c6fe5c2f6fe2383ef9588cb190"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12966,9 +12999,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ab0c3e003f457203702e4753aa5fe9e762380543fada44650b1217e4aa5a5"
+checksum = "841d717c0f465f5371569e6fdc25b6f32d47c15d6e4c92b3b779e1c9b18b951d"
 dependencies = [
  "ahash",
  "hash-db",
@@ -12990,9 +13023,9 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff74bf12b4f7d29387eb1caeec5553209a505f90a2511d2831143b970f89659"
+checksum = "bccf96fefae339dee7c4453f91be64eb28cce4c2fe82130445cf096b18b2c081"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13100,9 +13133,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0473f6e6cd7296675188f88b2c29dccea328f9f88ccb18f3a79048505ce7dc2a"
+checksum = "7eab4e71683cd8ceb50c1c77badc49772148699ffe33a3e4dbbdb5ea34d90e19"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -13115,9 +13148,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "13.0.1"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc905526a2619dfaa17d0d32d1daa6885fdf4eb2fead2e37411eb9d0a91013e"
+checksum = "f2b7b5f531c6bf9629514ef8e5fda0e9e80dd84516957f710940d0e01d3fb36c"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -13134,9 +13167,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd94fb9634d6276b74b7ee9ec5b761c52c30ec40b7c0a381711c5d25c3a0141"
+checksum = "b0517f2de0dd59ecc2693c0cb707ac30cee3d6576978b7287a4c3c9791b7792f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13157,9 +13190,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd7135969e580a14b73bf65fd25d714f3b20c3b2e94ff0949c148820ab3a79d"
+checksum = "7a5b83ea34a2ba2083c6f5bfec468fb00535d0e0788a78237d06da32dba76be9"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -13213,37 +13246,17 @@ dependencies = [
 
 [[package]]
 name = "str0m"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48572247f422dcbe68630c973f8296fbd5157119cd36a3223e48bf83d47727"
+checksum = "6706347e49b13373f7ddfafad47df7583ed52083d6fc8a594eb2c80497ef959d"
 dependencies = [
  "combine",
  "crc",
+ "fastrand 2.1.0",
  "hmac 0.12.1",
  "once_cell",
  "openssl",
  "openssl-sys",
- "rand 0.8.5",
- "sctp-proto",
- "serde",
- "sha-1 0.10.1",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "str0m"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f10d3f68e60168d81110410428a435dbde28cc5525f5f7c6fdec92dbdc2800"
-dependencies = [
- "combine",
- "crc",
- "hmac 0.12.1",
- "once_cell",
- "openssl",
- "openssl-sys",
- "rand 0.8.5",
  "sctp-proto",
  "serde",
  "sha-1 0.10.1",
@@ -13332,9 +13345,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bbe199ad82e3b69312a50b7024db70568d1bc1c4de6c21d89a2efd6cd59104"
+checksum = "8d077968f7a3352f4cd8791f9fc3553cca050fd3499f9ba602fe956813e8730d"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -13365,9 +13378,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec3140547debbca2c3cfa23d4d1b3e08761c09f67ac6fa5c9467b7f82d3e4e9"
+checksum = "6abf207b8db70d0ed674fac384e616a4613a93cd7f91ec7e6103c075be4b23cc"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13383,17 +13396,26 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "22.0.1"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6567b61eca9459dbe71385caef9f6eab826abbd4a0743abf27034d96d34b9062"
+checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
 dependencies = [
+ "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.14",
@@ -13945,9 +13967,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518b1159d234d0833152f6f60501ed28a04e9e263293746dad886ec0a8bb20e7"
+checksum = "d07f52b2b1a1c1c21094bd0b6fdcf1b7dbe785b937b30e82dba688d55d988efb"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -14825,15 +14847,16 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b641fb4783e441a32ddc3e3f7927a6092cec39af9de2f85becacba412b6815"
+checksum = "c0623e48f65c5e5368c7044cbd09c79bfc6418b258ad31892936a203b8b5509a"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -14851,6 +14874,7 @@ dependencies = [
  "pallet-beefy-mmr",
  "pallet-collective",
  "pallet-conviction-voting",
+ "pallet-delegated-staking",
  "pallet-democracy",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
@@ -14932,9 +14956,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55241a1b789ae6acf4bbe62687f2876fa83b151abf3d94e275c92ba4a2b59fe8"
+checksum = "c68089302095f1bf7fada4ab0a42aeee1d9b56280bcab18cf6359c35cae761b7"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15012,7 +15036,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core 0.51.1",
+ "windows-core",
  "windows-targets 0.48.5",
 ]
 
@@ -15023,15 +15047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -15363,9 +15378,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-fee-payment-runtime-api"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08b02854d1e3f844dec37dcf5897524f8e7ac6f227d225cba4ab43dadd0b691"
+checksum = "1d4261279994b1cb0d16a77cc12734fca18b88b56b65b8740de543af6d6a17dc"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -15379,9 +15394,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "9.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9498be6aff2d380250c4b155faaebe4a83da181a00402dedac6c8166850198"
+checksum = "87fb4f14094d65c500a59bcf540cf42b99ee82c706edd6226a92e769ad60563e"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,9 +6524,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca700e816a32739ab9480065a2546181f83e743c93f74b244463dd87b48e5aa"
+checksum = "c30c5fb9fae081c95545017bac69ca78f875fccf3bebfd142e1388bb2251fb66"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -6558,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0cb1d904c58964cf5015adc7683fb9467b8b7e8f281619aae403f43dc2c48c"
+checksum = "32b5eaf092c699d6a7e4904ccc871868f2cb715ad7e2e4dd72b7ff0720fd203a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6569,9 +6569,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "10.0.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c611f7343efdff673fec3090ab4ed5c32c63f9756f25f666fb453ef33b26bafb"
+checksum = "e1330375dcced95509e3cca7ef6b1c3fac648df995b86d39467d082ba981dc46"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ color-print = "0.3.4"
 docify = "0.2.8"
 futures = "0.3.30"
 hex-literal = "0.4.1"
-jsonrpsee = { version = "0.22", features = ["server"] }
+jsonrpsee = { version = "0.22.5", features = ["server"] }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.11.1", default-features = false, features = [
     "derive",
@@ -32,98 +32,97 @@ smallvec = "1.11.2"
 
 # Build
 substrate-build-script-utils = "11.0.0"
-substrate-wasm-builder = "22.0.0"
+substrate-wasm-builder = "23.0.0"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-frame-benchmarking = { version = "34.0.0", default-features = false }
-frame-benchmarking-cli = "38.0.0"
-frame-executive = { version = "34.0.0", default-features = false }
-frame-support = { version = "34.0.0", default-features = false }
-frame-system = { version = "34.0.1", default-features = false }
-frame-system-benchmarking = { version = "34.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "32.0.0", default-features = false }
-frame-try-runtime = { version = "0.40.0", default-features = false }
-pallet-aura = { version = "33.0.0", default-features = false }
-pallet-authorship = { version = "34.0.0", default-features = false }
-pallet-balances = { version = "35.0.0", default-features = false }
-pallet-message-queue = { version = "37.0.0", default-features = false }
-pallet-session = { version = "34.0.0", default-features = false }
-pallet-sudo = { version = "34.0.0", default-features = false }
-pallet-timestamp = { version = "33.0.0", default-features = false }
-pallet-transaction-payment = { version = "34.0.0", default-features = false }
-pallet-transaction-payment-rpc = "36.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "34.0.0", default-features = false }
-sc-basic-authorship = "0.40.0"
-sc-chain-spec = "33.0.0"
-sc-cli = "0.42.0"
-sc-client-api = "34.0.0"
-sc-offchain = "35.0.0"
-sc-consensus = "0.39.1"
-sc-executor = "0.38.0"
-sc-network = "0.40.0"
-sc-network-sync = "0.39.0"
-sc-rpc = "35.0.0"
-sc-service = "0.41.0"
-sc-sysinfo = "33.0.0"
-sc-telemetry = "20.0.0"
-sc-tracing = "34.0.0"
-sc-transaction-pool = "34.0.0"
-sc-transaction-pool-api = "34.0.0"
-sp-api = { version = "32.0.0", default-features = false }
-sp-block-builder = { version = "32.0.0", default-features = false }
-sp-blockchain = "34.0.0"
-sp-consensus-aura = { version = "0.38.0", default-features = false }
-sp-core = { version = "33.0.1", default-features = false }
-sp-io = { version = "36.0.0", default-features = false }
-sp-genesis-builder = { version = "0.13.0", default-features = false }
-sp-inherents = { version = "32.0.0", default-features = false }
-sp-keystore = "0.39.0"
-sp-offchain = { version = "32.0.0", default-features = false }
-sp-runtime = { version = "37.0.0", default-features = false }
-sp-session = { version = "33.0.0", default-features = false }
+frame-benchmarking = { version = "35.0.0", default-features = false }
+frame-benchmarking-cli = "39.0.0"
+frame-executive = { version = "35.0.0", default-features = false }
+frame-support = { version = "35.0.0", default-features = false }
+frame-system = { version = "35.0.0", default-features = false }
+frame-system-benchmarking = { version = "35.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "33.0.0", default-features = false }
+frame-try-runtime = { version = "0.41.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.3.0", default-features = false }
+pallet-aura = { version = "34.0.0", default-features = false }
+pallet-authorship = { version = "35.0.0", default-features = false }
+pallet-balances = { version = "36.0.0", default-features = false }
+pallet-message-queue = { version = "38.0.0", default-features = false }
+pallet-session = { version = "35.0.0", default-features = false }
+pallet-sudo = { version = "35.0.0", default-features = false }
+pallet-timestamp = { version = "34.0.0", default-features = false }
+pallet-transaction-payment = { version = "35.0.0", default-features = false }
+pallet-transaction-payment-rpc = "37.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "35.0.0", default-features = false }
+sc-basic-authorship = "0.41.0"
+sc-chain-spec = "34.0.0"
+sc-cli = "0.43.0"
+sc-client-api = "=35.0.0"
+sc-offchain = "36.0.0"
+sc-consensus = "0.40.0"
+sc-executor = "0.39.0"
+sc-network = "0.41.0"
+sc-network-sync = "0.40.0"
+sc-rpc = "36.0.0"
+sc-service = "0.42.0"
+sc-sysinfo = "34.0.0"
+sc-telemetry = "21.0.0"
+sc-tracing = "35.0.0"
+sc-transaction-pool = "35.0.0"
+sc-transaction-pool-api = "35.0.0"
+sp-api = { version = "33.0.0", default-features = false }
+sp-block-builder = { version = "33.0.0", default-features = false }
+sp-blockchain = "35.0.0"
+sp-consensus-aura = { version = "0.39.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-io = { version = "37.0.0", default-features = false }
+sp-genesis-builder = { version = "0.14.0", default-features = false }
+sp-inherents = { version = "33.0.0", default-features = false }
+sp-keystore = "0.40.0"
+sp-offchain = { version = "33.0.0", default-features = false }
+sp-runtime = { version = "=38.0.0", default-features = false }
+sp-session = { version = "34.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = "32.0.0"
-sp-transaction-pool = { version = "32.0.0", default-features = false }
-sp-version = { version = "35.0.0", default-features = false }
-substrate-frame-rpc-system = "34.0.0"
+sp-timestamp = "33.0.0"
+sp-transaction-pool = { version = "33.0.0", default-features = false }
+sp-version = { version = "36.0.0", default-features = false }
+substrate-frame-rpc-system = "35.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
 pallet-contracts = { version = "33.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "13.0.0", default-features = false }
-polkadot-cli = "13.0.0"
-polkadot-parachain-primitives = { version = "12.0.0", default-features = false }
-polkadot-primitives = "13.0.0"
-polkadot-runtime-common = { version = "13.0.0", default-features = false }
-xcm = { version = "13.0.1", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "13.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "13.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "14.0.0", default-features = false }
+polkadot-cli = "14.0.0"
+polkadot-parachain-primitives = { version = "13.0.0", default-features = false }
+polkadot-primitives = "14.0.0"
+polkadot-runtime-common = { version = "14.0.0", default-features = false }
+xcm = { version = "14.0.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "14.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "14.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.13.0"
-cumulus-client-collator = "0.13.0"
-cumulus-client-consensus-aura = "0.13.0"
-cumulus-client-consensus-common = "0.13.0"
-cumulus-client-consensus-proposer = "0.13.0"
-cumulus-client-service = "0.13.0"
-cumulus-pallet-aura-ext = { version = "0.13.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.13.0", default-features = false, features = [
-    "parameterized-consensus-hook",
-] }
-cumulus-pallet-session-benchmarking = { version = "15.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.13.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.13.0", default-features = false }
-cumulus-primitives-aura = { version = "0.13.0", default-features = false }
-cumulus-primitives-core = { version = "0.13.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.13.0"
-cumulus-primitives-storage-weight-reclaim = { version = "4.0.0", default-features = false }
-cumulus-primitives-utility = { version = "0.13.0", default-features = false }
-cumulus-relay-chain-interface = "0.13.0"
-pallet-collator-selection = { version = "15.0.0", default-features = false }
-parachains-common = { version = "13.0.0", default-features = false }
-parachain-info = { version = "0.13.0", package = "staging-parachain-info", default-features = false }
+cumulus-client-cli = "0.14.0"
+cumulus-client-collator = "0.14.0"
+cumulus-client-consensus-aura = "0.14.0"
+cumulus-client-consensus-common = "0.14.0"
+cumulus-client-consensus-proposer = "0.14.0"
+cumulus-client-service = "0.14.0"
+cumulus-pallet-aura-ext = { version = "0.14.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.14.0", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "16.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.14.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.14.0", default-features = false }
+cumulus-primitives-aura = { version = "0.14.0", default-features = false }
+cumulus-primitives-core = { version = "0.14.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.14.0"
+cumulus-primitives-storage-weight-reclaim = { version = "5.0.0", default-features = false }
+cumulus-primitives-utility = { version = "0.14.0", default-features = false }
+cumulus-relay-chain-interface = "0.14.0"
+pallet-collator-selection = { version = "16.0.0", default-features = false }
+parachains-common = { version = "14.0.0", default-features = false }
+parachain-info = { version = "0.14.0", package = "staging-parachain-info", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "35.0.0", default-featu
 sc-basic-authorship = "0.41.0"
 sc-chain-spec = "34.0.0"
 sc-cli = "0.43.0"
-sc-client-api = "=35.0.0"
+sc-client-api = "35.0.0"
 sc-offchain = "36.0.0"
 sc-consensus = "0.40.0"
 sc-executor = "0.39.0"
@@ -83,7 +83,7 @@ sp-genesis-builder = { version = "0.14.0", default-features = false }
 sp-inherents = { version = "33.0.0", default-features = false }
 sp-keystore = "0.40.0"
 sp-offchain = { version = "33.0.0", default-features = false }
-sp-runtime = { version = "=38.0.0", default-features = false }
+sp-runtime = { version = "38.0.0", default-features = false }
 sp-session = { version = "34.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-timestamp = "33.0.0"
@@ -93,7 +93,7 @@ substrate-frame-rpc-system = "35.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
 # Contracts
-pallet-contracts = { version = "33.0.0", default-features = false }
+pallet-contracts = { version = "34.0.0", default-features = false }
 
 # Polkadot
 pallet-xcm = { version = "14.0.0", default-features = false }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -8,7 +8,7 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
+pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -31,6 +31,7 @@ frame-support.workspace = true
 frame-system.workspace = true
 frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
+frame-metadata-hash-extension.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
 pallet-aura.workspace = true
 pallet-authorship.workspace = true
@@ -97,6 +98,7 @@ std = [
     "frame-system-rpc-runtime-api/std",
     "frame-system/std",
     "frame-try-runtime/std",
+    "frame-metadata-hash-extension/std",
     "log/std",
     "pallet-aura/std",
     "pallet-authorship/std",
@@ -181,3 +183,16 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+# Enable the metadata hash generation.
+#
+# This is hidden behind a feature because it increases the compile time.
+# The wasm binary needs to be compiled twice, once to fetch the metadata,
+# generate the metadata hash and then a second time with the
+# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
+# extension.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
+# A convenience feature for enabling things when doing a build
+# for an on-chain release.
+on-chain-release-build = ["metadata-hash"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,7 +1,17 @@
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[docify::export(template_enable_metadata_hash)]
+fn main() {
+    substrate_wasm_builder::WasmBuilder::init_with_defaults()
+        .enable_metadata_hash("UNIT", 12)
+        .build();
+}
+
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
     substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
+/// The wasm builder is deactivated when compiling
+/// this crate for wasm to speed up the compilation.
 #[cfg(not(feature = "std"))]
 fn main() {}

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -96,7 +96,7 @@ impl_runtime_apis! {
             Runtime::metadata_at_version(version)
         }
 
-        fn metadata_versions() -> sp_std::vec::Vec<u32> {
+        fn metadata_versions() -> Vec<u32> {
             Runtime::metadata_versions()
         }
     }
@@ -320,7 +320,7 @@ impl_runtime_apis! {
 
             use frame_system_benchmarking::Pallet as SystemBench;
             impl frame_system_benchmarking::Config for Runtime {
-                fn setup_set_code_requirements(code: &sp_std::vec::Vec<u8>) -> Result<(), BenchmarkError> {
+                fn setup_set_code_requirements(code: &Vec<u8>) -> Result<(), BenchmarkError> {
                     ParachainSystem::initialize_for_set_code_benchmark(code.len() as u32);
                     Ok(())
                 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -242,6 +242,10 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
     type WeightInfo = (); // Configure based on benchmarking results.
     type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
+    // Limit the number of messages and signals a HRML channel can have at most
+    type MaxActiveOutboundChannels = ConstU32<128>;
+    // Limit the number of HRML channels
+    type MaxPageSize = ConstU32<{ 1 << 16 }>;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -110,6 +110,7 @@ pub type SignedExtra = (
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
     cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+    frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
Follow the PR: https://github.com/r0gue-io/base-parachain/pull/38

- Compare `pallet-contracts`: [`v1.12.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.12.0/substrate/frame/contracts) and [`v1.13.0`](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.13.0/substrate/frame/contracts)

## CHANGLOG
- [Contracts: Rework host fn benchmarks ](https://github.com/paritytech/polkadot-sdk/commit/493ba5e2a144140d5018647b25744b0aac854ffd)
- [Add READ_ONLY flag to contract call function](https://github.com/paritytech/polkadot-sdk/commit/3e8416456a27197bd1bbb7fc8149d941d9167f4d#diff-fe70bd6777817c36eac74166d6e89dfea9f263fe3ea6669747e27d21707f65da): This PR implements the `READ_ONLY` flag to be used as a `Callflag` in the `call` function. The flag indicates that the callee is restricted from modifying the state during call execution. It is equivalent to Ethereum's [STATICCALL](https://eips.ethereum.org/EIPS/eip-214).