### PR TITLE
chore: upgrade to stable2407

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1679,7 +1679,7 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "url",
 ]
 
@@ -1700,18 +1700,18 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73aa933b4c011122abe0657b282fd46caa86caf2ae6e4ea624030fe87e7cfbc"
+checksum = "722a1d7edee069aed24eb5c23b765df386bccbd5e0b36bcde48e7339ac0648ce"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1736,17 +1736,17 @@ dependencies = [
  "sc-telemetry",
  "sc-utils",
  "schnellru",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents 34.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -1776,10 +1776,10 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-timestamp",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-trie",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1794,9 +1794,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -1814,16 +1814,16 @@ dependencies = [
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-version 37.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-version",
  "tracing",
 ]
 
@@ -1840,13 +1840,13 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-crypto-hashing",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-trie 37.0.0",
+ "sp-trie",
  "tracing",
 ]
 
@@ -1869,11 +1869,11 @@ dependencies = [
  "rand",
  "sc-client-api",
  "sc-consensus",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.0",
- "sp-version 37.0.0",
+ "sp-runtime",
+ "sp-version",
  "tracing",
 ]
 
@@ -1906,12 +1906,12 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
@@ -1922,15 +1922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd47d663082f3991d0e3233392ea96ee692669330601afffa9fae60a024ce37a"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1945,28 +1945,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-trie",
+ "sp-version",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
+ "staging-xcm-builder",
  "trie-db",
 ]
 
@@ -1988,12 +1988,12 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e64f3d961ec623d65207539246c134880933f32d76831c070c78da238e49a1b"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2003,12 +2003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea5659b958f2ffcbf6bdc31ab22ee2abf218878e02213f2d4f809a7f1233a4c6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-xcm",
 ]
 
@@ -2021,9 +2021,9 @@ dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -2031,11 +2031,11 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -2045,11 +2045,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e7825bcf3cc6c962a5b9b9f47e02dc381109e521d0bc00cad785c65da18471"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
+ "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus-aura",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2059,13 +2059,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "114859ea473b98046ba46eab82a1830329294015673def6fbadcf34662df4e6f"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
- "sp-trie 37.0.0",
+ "sp-api",
+ "sp-runtime",
+ "sp-trie",
  "staging-xcm",
 ]
 
@@ -2080,10 +2080,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ checksum = "421f03af054aac7c89e87a49e47964886e53a8d7395990eab27b6f201d42524f"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie 37.0.0",
+ "sp-trie",
 ]
 
 [[package]]
@@ -2106,12 +2106,12 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2121,17 +2121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490b10e4805645545785f5b38b3689d466cc9c5354cf8b9b0847b533a2bc7bb4"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 37.0.0",
+ "frame-support",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -2152,11 +2152,11 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -2172,10 +2172,10 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
- "sp-state-machine 0.43.0",
- "sp-version 37.0.0",
+ "sp-state-machine",
+ "sp-version",
  "thiserror",
 ]
 
@@ -2191,7 +2191,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "polkadot-core-primitives 15.0.0",
+ "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
@@ -2205,11 +2205,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2240,14 +2240,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-version 37.0.0",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2264,9 +2264,9 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -3083,50 +3083,24 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709b26657ebbba53dc7bb616577375ca462b20fef1b00e8d9b20d2435e87f7bc"
-dependencies = [
- "frame-support 36.0.1",
- "frame-support-procedural",
- "frame-system 36.1.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 33.0.0",
- "sp-application-crypto 37.0.0",
- "sp-core",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48554572bd164ee905a6ff3378e46c2101610fd2ffe3110875a6503a240fb3d7"
 dependencies = [
- "frame-support 37.0.0",
+ "frame-support",
  "frame-support-procedural",
- "frame-system 37.1.0",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-runtime-interface",
  "sp-storage",
  "static_assertions",
@@ -3143,9 +3117,9 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "gethostname",
  "handlebars",
  "itertools 0.11.0",
@@ -3165,19 +3139,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder 0.15.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
- "sp-trie 37.0.0",
+ "sp-trie",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3202,14 +3176,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772f6843543fea5d5083f8f7fe714632f6ab7a230a0a805ccc669e97330494a2"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3219,15 +3193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfc9b1cdc305826ef1196675a53ef7f2db8967a6cf5632775119c41d6f4e299"
 dependencies = [
  "aquamarine",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing",
 ]
 
@@ -3251,54 +3225,12 @@ checksum = "4033a2b473472e7ad29ff501d3cedff36f8eaa26f61654d19b6b5cf3e1885296"
 dependencies = [
  "array-bytes",
  "docify",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
-]
-
-[[package]]
-name = "frame-support"
-version = "36.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4d08149c28010bfa568dcfa832aea628fb794d4243794a13b1bdef1aa66fb1"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata",
- "frame-support-procedural",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 33.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.14.0",
- "sp-inherents 33.0.0",
- "sp-io 37.0.0",
- "sp-metadata-ir",
- "sp-runtime 38.0.1",
- "sp-staking 33.0.0",
- "sp-state-machine 0.42.0",
- "sp-std",
- "sp-tracing",
- "sp-weights",
- "static_assertions",
- "tt-call",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3324,18 +3256,18 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.15.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -3389,43 +3321,22 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "36.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6a0e7bb6503facdcc6f8e19c83cd0bfc8bbbd268522b1a50e107dfc6b972d"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 36.0.1",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std",
- "sp-version 36.0.0",
- "sp-weights",
-]
-
-[[package]]
-name = "frame-system"
 version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043790fff021477061b207fd6b33743793b63fc64a583358956787229d039717"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 37.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "sp-version 37.0.0",
+ "sp-version",
  "sp-weights",
 ]
 
@@ -3435,13 +3346,13 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10fb34e948ce86f8e2ceb04d25a0edaa26e308150b6b7c8ce0cbb0e4cd814131"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3452,7 +3363,7 @@ checksum = "475c4f8604ba7e4f05cd2c881ba71105093e638b9591ec71a8db14a64b3b4ec3"
 dependencies = [
  "docify",
  "parity-scale-codec",
- "sp-api 34.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -3461,10 +3372,10 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec60be1ddc39bd312496e58b2dd82e5f3d1e0609b69f9586ba6967a36453e495"
 dependencies = [
- "frame-support 37.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5776,13 +5687,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5794,11 +5705,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6465,17 +6376,17 @@ version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6847af5ada683672e4ba5307edd30935b523b96ddd3e6c0d9ae538967e7b6e72"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6484,13 +6395,13 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cf98e523678604f17e784986e789f515bb367dc5cf41f8f966b934ea2fb9d5"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6499,16 +6410,16 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8aba8d3470ea8ca27a8d3fecce2896094d22e7b3109120b01d0d5d2553f5a6d"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
- "pallet-transaction-payment 37.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6517,15 +6428,15 @@ version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd34007f64b1159232feacc431ae88b8319e16e594ed6ffc2c1a10ecf6e0ad64"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6534,15 +6445,15 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b4c3fc3c5af69af275ee8f1fc70aa73d0633b0cd818c603a2e8b483d4a9ccb"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6551,14 +6462,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e950b8368ef4af6af91d10061d5fc587ee92ed360e4b5bc32454a68842ccafe2"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6567,12 +6478,12 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddfa02ecfdd0bfa4841dc16ebd3bdd0d1918751b845f4b36b29c01bfaf75b5b"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6581,22 +6492,22 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4cee370246a2a8fa7d62b02b96febde7c8b09d18c9b8ce3a35c20a142379c8"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6607,35 +6518,18 @@ checksum = "5143d9c729fe3f02a3ff8d9800dd538717a35f2738aa35828347a060251f41ca"
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878e240962d3887f0e0654ac343a18845adb95ad493c9d4d5e803c015d4a4c3"
-dependencies = [
- "docify",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "sp-std",
 ]
 
 [[package]]
@@ -6645,13 +6539,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267f2b4c64e06d340fab1e48267e815dc2afaf8e6da16369b26b5c9e1e65f1aa"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6660,8 +6554,8 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce02e01c97af95523cc344f05f3c418de43de7d6bc89bbe1e8a640e773146df4"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6669,9 +6563,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6682,8 +6576,8 @@ checksum = "ebe1ff4ef6dd47ffa01cc390e5505491f65527852a8fe306ac1f82ebb41ee5e3"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6691,12 +6585,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -6705,16 +6599,16 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b025a04d02a33335672b144d58a824ca25c45848867180dbc416618f43d3408"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6724,16 +6618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce40525635682724f4ed243f6be36951df424b24703913fb696d6933e1db55e"
 dependencies = [
  "bitvec",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6742,17 +6636,17 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac635059b34dc038781c6d8892aa90327ec2491d4afdcace97e6d66e5ca9da3"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6761,18 +6655,18 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e680a751ac8ea4a820096b9b480457a10abd5ce495e65c24457993ad846d4c0"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6781,31 +6675,31 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b3d561c8e207ecd55cd77d040444f1525a7f6246c5f46a8e7211013ae04b8d"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6989ac82690f981959b0d38ac6d6d52fc06bf00a035548d62b9a2e9c220376"
+checksum = "ef308fa6da2363f32616a324adb11318fdbeefe998f974222a99e1e3408c6de4"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "frame-system 36.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances 37.0.0",
+ "pallet-balances",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
@@ -6815,13 +6709,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api 33.0.0",
+ "sp-api",
  "sp-core",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "staging-xcm",
- "staging-xcm-builder 15.0.0",
+ "staging-xcm-builder",
  "wasm-instrument",
  "wasmi 0.32.3",
 ]
@@ -6839,9 +6733,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1330375dcced95509e3cca7ef6b1c3fac648df995b86d39467d082ba981dc46"
+checksum = "16f74b000590c33fadea48585d3ae3f4b7867e99f0a524c444d5779f36b9a1b6"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6857,14 +6751,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755ac1497eb1b7509f501fabe1f6d8694b8e316aa10c3987f470a2fdeb4e597f"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6873,12 +6767,12 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff872d2b23db76b7fc47f4ff20d1a3b713b56367b6c2c9560662213ddd2be354"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6887,16 +6781,16 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4270bbcd896cc6aa04e0bbb07795b715b5320eacca6f46e7c705c0d70cf66357"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6905,10 +6799,10 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b02a05136d6c5b46fc4963232ffc2069d444100c79fa524627b307fcaea78cd2"
 dependencies = [
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
@@ -6916,9 +6810,9 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -6928,12 +6822,12 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd65dad4b4de7ec4b0d1631d1e8ad8766eaaa0ab4e871ec6c73a1e894c68afc9"
 dependencies = [
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-system 37.1.0",
+ "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6942,17 +6836,17 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b619d7819e43ff1cc6201fb4cf73d6b65f6b6975c1014a1d73ac88e60986b19c"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6962,16 +6856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "283f467fdee4862f2fcb7ae354c0380e8e763fc465b6b7c560950aa0cce90731"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6980,21 +6874,21 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a9db737c0ad83212dd874658194b1be7d9cb3c093599aa02573645f9b991f4"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7004,14 +6898,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83fd8ea40185db968ecec0c4782e3cdf9a788ad4fc4a5870eeb0d0981de2680"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7020,18 +6914,18 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be560a30bb7b6e829c9827edb10d1e30facbc923d4fd9ee86476e82eecdda27d"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7040,15 +6934,15 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0bd6b183d5bb4c33693c47d8012bb1026b88fff49588dcf5d320a3117f2b8d"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7057,15 +6951,15 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2168417fce51f72b11973f0bb9eab9bde44e4bbad4fc55090e53255e9104b7"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7075,16 +6969,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0043ed8838d63b195365119311cef59e2cf32f7a7ca55128a4ae1f9fd80330e2"
 dependencies = [
  "environmental",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7094,16 +6988,16 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82afef201023849dc5d65b6793d4c5f58d91cad42a0c552d1308232dc281d0a"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-mmr-primitives",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7112,14 +7006,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b836d56979a4cd33b68bca09ea34bd0eb524fad8711cb6471ec84a5c3318ea6f"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7128,14 +7022,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5cd85ccaeed4526c5165fa3b66d1458404ce3525d99da22060654edb98fc03"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7144,16 +7038,16 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d192e723eda9ca952ac184f9cd403e5aa62fa5bc85ac3e1c3c46b65b5923c7a2"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-tracing",
 ]
 
@@ -7163,19 +7057,19 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0ccd27fa44dc3d48287bc26094c4a7c29983eea415d2d2862d5ffac1496e0d7"
 dependencies = [
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "pallet-bags-list",
  "pallet-delegated-staking",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-staking 34.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7186,7 +7080,7 @@ checksum = "3c7648bab22c3e941124d3f814e3afbdc4287510241fdda7ca626370c796cd4b"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 34.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -7195,15 +7089,15 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b364e0756f83bcdfd69fd3255a8088f9f048223850f7b86a42742c2e667c694"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7212,13 +7106,13 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f327028dc9ad84f9b5751575f8886f18117aa9d09e5ade98d0bd340c6a6717c0"
 dependencies = [
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-babe",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -7226,8 +7120,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7237,15 +7131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6244519de5c956f37f6d34ca2cbbd00e8511ec03e65f32f9e18e9ae39137af"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7254,15 +7148,15 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d77b400c54d7d6645a768a62a430dba851e553d9eef9376cfa1ab0e13acf13"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7271,13 +7165,13 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a6f11efebb88d9c64fa3335fb376d3603302ee46bbbe36fff8e1d0e01d0d4"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7286,17 +7180,17 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc2be6163035e045cd82932ae4fe0747207578ac176032119752fd592a5e1cf"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7305,13 +7199,13 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "769e3fe4e7445d095814447961d674a01b5feea0d07424ef82ef844f12d8e9dc"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7321,16 +7215,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77142a71cbc241ebc5ec11d65868379b7d5440e07ae7545f1bfd5933485f1a13"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7339,13 +7233,13 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9c14b36f689daf3d2110be82aa64f55f2405742f148a7f24187c5d88fb4648"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7355,14 +7249,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca20e5a34daccd584fa00e2239113cbb7e6097d03064a8e7dc4df0640ac8dfce"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7372,20 +7266,20 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84da59cf6db5db9a4424a5967787bf4ea20bfa903988a2438429c09a48365acf"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -7394,14 +7288,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "018aab2ea95d8aacd1d6e7aab408a0bef45087269b00646a74efac859952175e"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
 ]
 
@@ -7411,16 +7305,16 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfcfe8e812f5e99f09526897955b4e1d93c4032f5303880a222001f5534c6c6"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha",
  "scale-info",
  "sp-arithmetic",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7429,10 +7323,10 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e59824a9ca557a64c4ba26331a2db84f91610e75620a497610287a16edfb52d7"
 dependencies = [
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7440,10 +7334,10 @@ dependencies = [
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-application-crypto 38.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7475,8 +7369,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3741b83293a288854283ea9baedba017ae8b34d7eff0f6166f3fcbde2c01228b"
 dependencies = [
  "parity-scale-codec",
- "sp-api 34.0.0",
- "sp-staking 34.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -7485,15 +7379,15 @@ version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bcdde046a530b78cf8caa8faef67208a38093658f5fa3668b183967df4ac82"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7503,31 +7397,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82e375c0a4c4ed079ae49bd2693548bd57178273b37631bcd7e817242d0f2b0"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "36.0.0"
+version = "36.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301332166bded1fb86eda22846287de6c7313c15dce87535aae3c956f5f2c9b"
+checksum = "14f264c80bef4ac3180e5cba619f319d7855cc89ba91b28b3f752620d9425b88"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-storage",
  "sp-timestamp",
 ]
@@ -7538,34 +7432,17 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb28f1cf5ded9cc71fe04eece85be06482c1b6544facb1092ebb18eeb3e23e2e"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fb6114223c8d967c3c2f21cbc845e8ea604ff7e21a8e59d119d5a9257ba886"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7574,14 +7451,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6b4889a0a8565cf0d6ecf3feef787c18ad2c529add4d90ec896873cd422eec"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7593,11 +7470,11 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7607,10 +7484,10 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1879d1f608f565d590fc7520a8d9977b868a412910f6381a5ebfa45acf8abcfb"
 dependencies = [
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -7621,16 +7498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee7b2c3dec2979b0ea7bc33f01d78d12ed58b556011c52513dfd422342df8f3"
 dependencies = [
  "docify",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7639,14 +7516,14 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db53b324a0d0f078b5e61434fb3f2f4a89d81481dfd799fa4a71d054b441672a"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7655,13 +7532,13 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271f52d5ec90583ce7bd7d302f89b9ebabe1a820dc3e162fc1e5b14889f3b12c"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7670,13 +7547,13 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69f9fedf59efa21db7724c78627e4118e74621e27d90f9b5fa96ad4cff076f3"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7686,20 +7563,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a8c373e1c15eaa72fada061ffc486d81ff8bdb253ce3d569908c97ed40a89c"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
 
@@ -7709,17 +7586,17 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5629e0639e2894d9a647a5146f63b219d7317f34196e91c42ab384f533cd999e"
 dependencies = [
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -7738,7 +7615,7 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "docify",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7766,14 +7643,14 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-timestamp",
  "staging-xcm",
  "substrate-build-script-utils",
@@ -7795,11 +7672,11 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7807,38 +7684,38 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder 0.15.0",
- "sp-inherents 34.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version 37.0.0",
+ "sp-version",
  "staging-parachain-info",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -7850,13 +7727,13 @@ checksum = "91304aa1eb95bdea1471bc3994fb8cb30a8d913bdcd2abe59a70abfaf3e49abf"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7865,11 +7742,11 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-parachain-info",
  "staging-xcm",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
 ]
 
@@ -8280,10 +8157,10 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
 ]
@@ -8305,23 +8182,10 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
  "tokio-util",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c72ee63bcf920f963cd7ac066759b0b649350c8ab3781a85a6aac87b1488f2"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-runtime 38.0.1",
- "sp-std",
 ]
 
 [[package]]
@@ -8333,7 +8197,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8356,7 +8220,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8373,7 +8237,7 @@ dependencies = [
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie 37.0.0",
+ "sp-trie",
  "thiserror",
 ]
 
@@ -8393,7 +8257,7 @@ dependencies = [
  "rand_chacha",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -8469,10 +8333,10 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
  "tracing-gum",
 ]
@@ -8553,9 +8417,9 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-keystore",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -8627,7 +8491,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 34.0.0",
+ "sp-inherents",
  "thiserror",
  "tracing-gum",
 ]
@@ -8680,12 +8544,12 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 15.0.0",
+ "polkadot-core-primitives",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "rand",
  "slotmap",
@@ -8725,7 +8589,7 @@ dependencies = [
  "libc",
  "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
@@ -8734,7 +8598,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8817,7 +8681,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8833,16 +8697,16 @@ dependencies = [
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
  "zstd 0.12.4",
 ]
@@ -8880,11 +8744,11 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8919,7 +8783,7 @@ dependencies = [
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8943,28 +8807,10 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61070d0ff28f596890def0e0d03c231860796130b2a43e293106fa86a50c9a9"
-dependencies = [
- "bounded-collections",
- "derive_more",
- "parity-scale-codec",
- "polkadot-core-primitives 14.0.0",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime 38.0.1",
- "sp-std",
- "sp-weights",
 ]
 
 [[package]]
@@ -8976,11 +8822,11 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -8994,21 +8840,21 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9034,15 +8880,15 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -9054,17 +8900,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0572bf05ac57526ed10597078e2598cb3ee9ae9b7eba605d222276bbf1cee44b"
 dependencies = [
  "bitvec",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -9073,7 +8919,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -9084,17 +8930,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-npos-elections",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -9105,7 +8951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4636dd0772d838fb2e3c4a54a6530f2921e80d6cde48eba0ecc029e6378f900"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-tracing",
@@ -9120,15 +8966,15 @@ dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -9136,26 +8982,26 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand",
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
  "staging-xcm",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-executor",
  "static_assertions",
 ]
 
@@ -9167,11 +9013,11 @@ checksum = "0fe2358dece71b78a73e193300f4a8e6b21c10c792a44586d5e4dd965553b5df"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-metadata-hash-extension",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -9182,7 +9028,7 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -9192,7 +9038,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives 15.0.0",
+ "polkadot-core-primitives",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -9217,7 +9063,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
@@ -9250,7 +9096,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9259,19 +9105,19 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.43.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version 37.0.0",
+ "sp-version",
  "sp-weights",
  "staging-xcm",
  "substrate-prometheus-endpoint",
@@ -9300,7 +9146,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking 34.0.0",
+ "sp-staking",
  "thiserror",
  "tracing-gum",
 ]
@@ -10246,11 +10092,11 @@ checksum = "27697241f5185ccee6eedf63a6db39a20ce71a5f834632ac78f5b219201c4e0a"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10260,7 +10106,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -10293,7 +10139,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -10302,7 +10148,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -10312,7 +10158,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -10320,20 +10166,20 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder 0.15.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 37.0.0",
+ "sp-version",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-runtime-apis",
@@ -10345,15 +10191,15 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc34894f6b251d166f2d607a61b1d5deef73d4ef6ea85e0074db3f0e366a65"
 dependencies = [
- "frame-support 37.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -10696,12 +10542,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10720,12 +10566,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10736,13 +10582,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f666f8ff11f96bf6d90676739eb7ccb6a156a4507634b7af83b94f0aa8195a50"
 dependencies = [
  "parity-scale-codec",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-trie 37.0.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10766,10 +10612,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.15.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-tracing",
 ]
 
@@ -10821,8 +10667,8 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime 39.0.0",
- "sp-version 37.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
 ]
@@ -10841,17 +10687,17 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
  "sp-storage",
- "sp-trie 37.0.0",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10877,9 +10723,9 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10897,12 +10743,12 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10922,17 +10768,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 34.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10958,8 +10804,8 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10967,9 +10813,9 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents 34.0.0",
+ "sp-inherents",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10986,14 +10832,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11018,8 +10864,8 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "sc-utils",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -11027,7 +10873,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11048,10 +10894,10 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11066,7 +10912,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11100,8 +10946,8 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -11109,7 +10955,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -11131,7 +10977,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11154,9 +11000,9 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -11171,14 +11017,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-trie",
+ "sp-version",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -11243,7 +11089,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11255,7 +11101,7 @@ dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -11282,12 +11128,12 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11332,7 +11178,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11359,7 +11205,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11377,7 +11223,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11400,7 +11246,7 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11435,7 +11281,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11458,7 +11304,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11505,12 +11351,12 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -11545,16 +11391,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
- "sp-version 37.0.0",
+ "sp-version",
  "tokio",
 ]
 
@@ -11574,8 +11420,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
- "sp-version 37.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
 ]
 
@@ -11624,12 +11470,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
- "sp-version 37.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11677,20 +11523,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.43.0",
+ "sp-state-machine",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-trie",
+ "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11742,7 +11588,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11764,7 +11610,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -11808,11 +11654,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11849,11 +11695,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11873,7 +11719,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12375,7 +12221,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12576,29 +12422,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e43fbf034e9dbaa8ffc6a238a22808777eb38c580f66fc6736d8511631789e"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro",
- "sp-core",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime 38.0.1",
- "sp-runtime-interface",
- "sp-state-machine 0.42.0",
- "sp-std",
- "sp-trie 36.0.0",
- "sp-version 36.0.0",
- "thiserror",
-]
-
-[[package]]
-name = "sp-api"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbce492e0482134128b7729ea36f5ef1a9f9b4de2d48ff8dde7b5e464e28ce75"
@@ -12612,11 +12435,11 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-state-machine",
+ "sp-trie",
+ "sp-version",
  "thiserror",
 ]
 
@@ -12637,20 +12460,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d96d1fc0f1c741bbcbd0dd5470eff7b66f011708cc1942b088ebf0d4efb3d93"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io 37.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8133012faa5f75b2f0b1619d9f720c1424ac477152c143e5f7dbde2fe1a958"
@@ -12659,7 +12468,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
 ]
 
 [[package]]
@@ -12686,9 +12495,9 @@ checksum = "519c33af0e25ba2dd2eb3790dc404d634b6e4ce0801bcc8fa3574e07c365e734"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12697,9 +12506,9 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74738809461e3d4bd707b5b94e0e0c064a623a74a6a8fe5c98514417a02858dd"
 dependencies = [
- "sp-api 34.0.0",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12712,12 +12521,12 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core",
  "sp-database",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
  "tracing",
 ]
@@ -12732,9 +12541,9 @@ dependencies = [
  "futures",
  "log",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -12747,11 +12556,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12765,12 +12574,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12784,14 +12593,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -12806,11 +12615,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12931,19 +12740,6 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd065854d96fd81521c103d0aaa287d4f08b9b15c9fae2a3bfb208b0812bf44"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 33.0.0",
- "sp-runtime 38.0.1",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "182812315871732372325f0ad42bb8b85a093a06dd77ae1eec997259f4c32aef"
@@ -12951,22 +12747,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53407ba38ec22ca4a16381722c4bd0b559a0428bc1713079b0d5163ada63186a"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 38.0.1",
- "thiserror",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12979,35 +12761,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5036cad2e48d41f5caf6785226c8be1a7db15bec14a9fd7aa6cca84f34cf689f"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive",
- "rustversion",
- "secp256k1",
- "sp-core",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine 0.42.0",
- "sp-std",
- "sp-tracing",
- "sp-trie 36.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -13030,9 +12785,9 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine 0.43.0",
+ "sp-state-machine",
  "sp-tracing",
- "sp-trie 37.0.0",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -13044,7 +12799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c0e20624277f578b27f44ecfbe2ebc2e908488511ee2c900c5281599f700ab3"
 dependencies = [
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -13089,8 +12844,8 @@ checksum = "3b0b017dd54823b6e62f9f7171a1df350972e5c6d0bf17e0c2f78680b5c31942"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -13104,10 +12859,10 @@ dependencies = [
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13122,7 +12877,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13131,9 +12886,9 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9de237d72ecffd07f90826eef18360208b16d8de939d54e61591fac0fcbf99"
 dependencies = [
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13160,33 +12915,6 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "38.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5273900f0b0bef48b2e1ff9c4fb5e188b8168ee5891418a427f4be2af92ee40f"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 37.0.0",
- "sp-arithmetic",
- "sp-core",
- "sp-io 37.0.0",
- "sp-std",
- "sp-weights",
- "tracing",
-]
-
-[[package]]
-name = "sp-runtime"
 version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5641385c2cd8e2252aacf35e0aff2f236331dfaea8dc11c5a4ec6bb36544450"
@@ -13203,10 +12931,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-std",
  "sp-weights",
  "tracing",
@@ -13254,25 +12982,11 @@ checksum = "d04fcd2d1270038be94d00103e8e95f7fbab9075dcc78096b91d8931ee970d73"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-core",
  "sp-keystore",
- "sp-runtime 39.0.0",
- "sp-staking 34.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0b7abfe66c07a3b6eb99e1286dfa9b6f3b057b0e986e7da2ccbf707f6c781a"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime 38.0.1",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -13286,28 +13000,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime 39.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211e528aa6e902261a343f7b40840aa3d66fe4ad3aadbd04a035f10baf96dbc5"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "smallvec",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie 36.0.0",
- "thiserror",
- "tracing",
- "trie-db",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13325,7 +13018,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie 37.0.0",
+ "sp-trie",
  "thiserror",
  "tracing",
  "trie-db",
@@ -13345,12 +13038,12 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek",
@@ -13383,8 +13076,8 @@ checksum = "72a1cb4df653d62ccc0dbce1db45d1c9443ec60247ee9576962d24da4c9c6f07"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -13406,8 +13099,8 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4bf251059485a7dd38fe4afeda8792983511cc47f342ff4695e2dcae6b5247"
 dependencies = [
- "sp-api 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13420,33 +13113,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.0",
- "sp-trie 37.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d717c0f465f5371569e6fdc25b6f32d47c15d6e4c92b3b779e1c9b18b951d"
-dependencies = [
- "ahash",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core",
- "sp-externalities",
- "thiserror",
- "tracing",
- "trie-db",
- "trie-root",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -13475,24 +13144,6 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccf96fefae339dee7c4453f91be64eb28cce4c2fe82130445cf096b18b2c081"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 38.0.1",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror",
-]
-
-[[package]]
-name = "sp-version"
 version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d521a405707b5be561367cd3d442ff67588993de24062ce3adefcf8437ee9fe1"
@@ -13503,7 +13154,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13608,11 +13259,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e65e4397580154b0f6760350f51a97afa2ecabcbb3cc133a5116940c1b36a6a"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13636,69 +13287,24 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847fa2afe1bed2751eaabf7b91fa4043037947f17653d7cc59ea202cc44c6bb8"
-dependencies = [
- "frame-support 36.0.1",
- "frame-system 36.1.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-transaction-payment 36.0.0",
- "parity-scale-codec",
- "polkadot-parachain-primitives 13.0.0",
- "scale-info",
- "sp-arithmetic",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-executor 15.0.0",
-]
-
-[[package]]
-name = "staging-xcm-builder"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bda935caf05b0d1bd929e0211bbc2d1815fa45977e72880f00b49f42688142"
 dependencies = [
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "scale-info",
  "sp-arithmetic",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-executor 16.0.0",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b98d8219449eaf02e71a7edf1a14b14d4c713dd01d9df66fde1ce30dba4d6d"
-dependencies = [
- "environmental",
- "frame-benchmarking 36.0.0",
- "frame-support 36.0.1",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io 37.0.0",
- "sp-runtime 38.0.1",
- "sp-std",
- "sp-weights",
- "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -13708,15 +13314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f6e90f1605540994f0186eaa713f1d636d3afc34cf0887b01b880921c845fc"
 dependencies = [
  "environmental",
- "frame-benchmarking 37.0.0",
- "frame-support 37.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
  "tracing",
@@ -13867,11 +13473,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13899,9 +13505,9 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
  "trie-db",
 ]
 
@@ -13923,10 +13529,10 @@ dependencies = [
  "polkavm-linker",
  "sc-executor",
  "sp-core",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-maybe-compressed-blob",
  "sp-tracing",
- "sp-version 37.0.0",
+ "sp-version",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.14",
@@ -15381,12 +14987,12 @@ checksum = "9e5fba32e087a2b7803ba3dae251f345eb0b577f2394e903cdb4efcfa27480e2"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking 37.0.0",
+ "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 37.0.0",
- "frame-system 37.1.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -15397,7 +15003,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances 38.0.0",
+ "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -15435,7 +15041,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment 37.0.0",
+ "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -15444,7 +15050,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives 14.0.0",
+ "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -15452,29 +15058,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder 0.15.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 34.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 37.0.0",
+ "sp-version",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-runtime-apis",
@@ -15486,15 +15092,15 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5b6e2fa3bd463410e65dbe7931f5b4ee19ae8db6d1c87071e38e9e3d17a616"
 dependencies = [
- "frame-support 37.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-builder 16.0.0",
+ "staging-xcm-builder",
 ]
 
 [[package]]
@@ -15908,13 +15514,13 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf11b1fb43e9beb4a3c1c613c3a791ff16ab270566c1ce80f346b09afdced1"
 dependencies = [
- "frame-support 37.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 34.0.0",
+ "sp-api",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-executor 16.0.0",
+ "staging-xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,14 +935,14 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7dae4d1ec894ee920195dd39070b279ef3c1d4d078c3fcf7336c93a1d502a9d"
+checksum = "a7a8db232b5330d750760bd830c3c836b9ec37922753d3446d5242367a682f05"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64901f2fde878bec8f4c3949b5e5ee6fb5de45dd19b45d9fcd6a23a859fd0cc"
+checksum = "237e5c0295e2fabf682015f71eb1c6b618b1dff926c8c91ed04927d773aee8ee"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1679,15 +1679,15 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2311f438161902135ff57db8a81ed3c701e33fd4bccbcc72e785f1efc73e1df3"
+checksum = "838e4a3a9761eef58b115b4119f755376a5906980c63ed7ca4eb0ca97b8629d0"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1700,18 +1700,18 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c45052da56eb1631e177812f47c9426cb2617a5bfcc4c76a746e6a4c660df2"
+checksum = "e73aa933b4c011122abe0657b282fd46caa86caf2ae6e4ea624030fe87e7cfbc"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1734,28 +1734,30 @@ dependencies = [
  "sc-consensus-babe",
  "sc-consensus-slots",
  "sc-telemetry",
+ "sc-utils",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 34.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b4de5c24c4304b509dffccb95218f22c2ef619a91aee85a3d9523b63347be2"
+checksum = "d7d8e8f79ff4fa132373bff0aba25860fbafd72334e030a9a368b15953556576"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1774,35 +1776,35 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
- "sp-trie",
- "sp-version",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e980b3e5c05415eaa4ac07f398bc8e74666811f3112f19a654ccb3a948018e"
+checksum = "f2584d98a9acf90ebe3829f1caf60bbdae1d08bec6cb4f0842b673aa7eeda4a1"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8d6844af4dbb35a925d493331b631f4ccd3b15568643e92afbf0ee7f4b22e3"
+checksum = "6d56ab22363fb62cf5bd23ea4a6ca6dce48fb8d1bce6b5689f13af562f447e7b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1812,24 +1814,24 @@ dependencies = [
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-version",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-version 37.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99367f72d7bce6d8996eb397d265290e4a982fbbc4b0fd7659e57a2ad5b6b7b"
+checksum = "e8ef3132e6f725d27bdb1be02a49b748f99ce3021e760c47b99c283d5a555f3f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1838,23 +1840,21 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "scale-info",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 37.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3bd944ef351edb61fdaca5bf6d9a964d7c7571bd0b0236ea51f167bec9b6f"
+checksum = "65326bc7edd8c1f6011b7a22da5fcd6b3f7f3966bfe841407325d9dce781193b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1869,19 +1869,19 @@ dependencies = [
  "rand",
  "sc-client-api",
  "sc-consensus",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 39.0.0",
+ "sp-version 37.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb134f1526eba4455290859ad34174ab787c8f36f509063f41eeac17202a8f78"
+checksum = "28edb3251c4a44110566554cfa266db7147131eec3027bd8425f5ad180c77775"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1906,39 +1906,38 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8af48090936c45483d489ee681acb54277763586b53fa3dbd17173aa474fc"
+checksum = "cd47d663082f3991d0e3233392ea96ee692669330601afffa9fae60a024ce37a"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d5509bd8ac95bafe158fa475278315175a4eb0422c2cd82e08e8b9dde035c"
+checksum = "e708b53cac377910e47aca6a64048433fe1c1db85013aec16a271d4967facb5d"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1946,28 +1945,28 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
  "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm-builder 16.0.0",
  "trie-db",
 ]
 
@@ -1985,48 +1984,46 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506daacefa861aa2909b64f26e76495ce029227fd8355b97e074cc1d5dc54ab2"
+checksum = "2e64f3d961ec623d65207539246c134880933f32d76831c070c78da238e49a1b"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5224285f60e5159bab549f458079d606a7f95ef779def8b89f1a244dc7cf81"
+checksum = "ea5659b958f2ffcbf6bdc31ab22ee2abf218878e02213f2d4f809a7f1233a4c6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adf5409618b21e754fef0ac70f257878d22d61c48fdeefcab666835dcb8e0f0"
+checksum = "1eab08b5d8e224557627cf4d3ed4c05fc9687446ec805c1772ce9f3662263229"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
@@ -2034,120 +2031,114 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7977947ad43a4cbc532ca33abcde136ae3deffdc7168b2ae253d73ccd371e4"
+checksum = "11e7825bcf3cc6c962a5b9b9f47e02dc381109e521d0bc00cad785c65da18471"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 15.0.0",
  "polkadot-primitives",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus-aura",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e64b89a839d5cfabebc1c797936e5eee791d0fa2322d91e86f8440a743ddb"
+checksum = "114859ea473b98046ba46eab82a1830329294015673def6fbadcf34662df4e6f"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "scale-info",
- "sp-api",
- "sp-runtime",
- "sp-std",
- "sp-trie",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df521e13b48278b86d02c61d6e44036d6d263deb5aaec4838b1751da8988d3d2"
+checksum = "6a09118ae7a386d65f9e86ef68ec681969370f8cebe41a7724d2aa8d6fd73ac5"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f973d2a7262c90e48dcd42062bcb1e0fbf48bbcdac4ea6df3d85212d8d8be5d"
+checksum = "421f03af054aac7c89e87a49e47964886e53a8d7395990eab27b6f201d42524f"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "6.0.2"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a7e13063f593f21534a7b64c96f311c40cd4d3c72649e0bd063a34506fdd70"
+checksum = "316c5b2fa5d1435ffda67a4b03143c119f188809a163989f88db3bcad63943a3"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05742c520065e3870d419683113ed7f6d35de66f0c80af6828e7878d1bb0ea94"
+checksum = "490b10e4805645545785f5b38b3689d466cc9c5354cf8b9b0847b533a2bc7bb4"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
+ "frame-support 37.0.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511675c9780fe8396e2b0c3ca8a04ff0ddc57d837fd9fe4086cb9aac1b107523"
+checksum = "a1db6bcd2fc89d78cb63c04413265b0bee067f6987ff20e11abc31467a3a56d5"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2161,18 +2152,18 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36abc0a30972529fad05c4fae9f6866ec6c3edfaf2e20977219c94a807d96ffa"
+checksum = "e652b84cc7cabbe3bc83a915d87e4b1a829ebc6781122e884b0f26334c5957f6"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2181,18 +2172,18 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
- "sp-state-machine",
- "sp-version",
+ "sp-state-machine 0.43.0",
+ "sp-version 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39ec9de6ed195263af022094d63689fc6a914f48f70d74eb3fed8ee48973ea3"
+checksum = "0ff5066f160423e7f886ddbff2cd789d7239ecd5e045eb3ea8ac38b3cb80f905"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2200,15 +2191,8 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures",
- "parking_lot 0.12.3",
- "polkadot-availability-recovery",
- "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 15.0.0",
  "polkadot-network-bridge",
- "polkadot-node-collation-generation",
- "polkadot-node-core-chain-api",
- "polkadot-node-core-prospective-parachains",
- "polkadot-node-core-runtime-api",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
@@ -2221,11 +2205,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2233,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22c43792fa5d56a2360bcdbdc58c47aafa23688072d2b6e61844864e69a15c8"
+checksum = "72681dcaf7ff00f7f48f17bd88344a21afb14b3e5f0a51e98d3816d1cd91faa5"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2256,14 +2240,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-storage",
- "sp-version",
+ "sp-version 37.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2273,31 +2257,29 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f4ab9d64a581d4a5431f2554f4602a4208c5e28b30be01af386e24d8447599"
+checksum = "cc76c015f5efa698671a2f52842abb84feb80c8da17bbe4201607fb9a7c62a5f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle 2.5.0",
  "zeroize",
@@ -3105,20 +3087,20 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709b26657ebbba53dc7bb616577375ca462b20fef1b00e8d9b20d2435e87f7bc"
 dependencies = [
- "frame-support",
+ "frame-support 36.0.1",
  "frame-support-procedural",
- "frame-system",
+ "frame-system 36.1.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 33.0.0",
+ "sp-application-crypto 37.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
@@ -3126,19 +3108,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-benchmarking-cli"
-version = "40.0.0"
+name = "frame-benchmarking"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49302558cac41cba0a28aa784615daea85c49253ecc6d6a6c4a8ee2f2303655a"
+checksum = "48554572bd164ee905a6ff3378e46c2101610fd2ffe3110875a6503a240fb3d7"
+dependencies = [
+ "frame-support 37.0.0",
+ "frame-support-procedural",
+ "frame-system 37.1.0",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface",
+ "sp-storage",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking-cli"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa62cef9f98e81ae37ab965604bdc2ed5e67be6d4e05b04bc5782494b890e5b1"
 dependencies = [
  "Inflector",
  "array-bytes",
  "chrono",
  "clap",
  "comfy-table",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "gethostname",
  "handlebars",
  "itertools 0.11.0",
@@ -3158,19 +3165,19 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.15.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 37.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3190,39 +3197,37 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ec289ebad5e601bb165cf7eb6ec2179ae34280ee310d0710a3111d4f8f8f94"
+checksum = "772f6843543fea5d5083f8f7fe714632f6ab7a230a0a805ccc669e97330494a2"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d878830330eaa9e8b886279c338556b05702d0059989cb51cfb226b70bf3fa4"
+checksum = "4dfc9b1cdc305826ef1196675a53ef7f2db8967a6cf5632775119c41d6f4e299"
 dependencies = [
  "aquamarine",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-tracing",
 ]
 
@@ -3240,25 +3245,25 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata-hash-extension"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf37fc730bf4b51e82a34c6357eebe32c04dbacf6525e0a7b9726f6a17ec9427"
+checksum = "4033a2b473472e7ad29ff501d3cedff36f8eaa26f61654d19b6b5cf3e1885296"
 dependencies = [
  "array-bytes",
  "docify",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-support"
-version = "36.0.0"
+version = "36.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512b517645f29d76c79e4c97bf8b0f4dcb6708a2af3be24b1956085dcdcf6ce5"
+checksum = "2f4d08149c28010bfa568dcfa832aea628fb794d4243794a13b1bdef1aa66fb1"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3277,18 +3282,60 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.14.0",
+ "sp-inherents 33.0.0",
+ "sp-io 37.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 38.0.1",
+ "sp-staking 33.0.0",
+ "sp-state-machine 0.42.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cae973c331b7f52ba18435713f9ed02bac20bd4fdedaaad57445d82f05eb9d"
+dependencies = [
+ "aquamarine",
+ "array-bytes",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 34.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.15.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
+ "sp-state-machine 0.43.0",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -3298,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94af68373e179c32c360b3c280497a9cf0f45a4f47f0ee6539a6c6c9cf2343"
+checksum = "1e4662a809f559aea6234bd90940fa29df583a3c8124a3cf923f66a0d21126b7"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3348,56 +3395,76 @@ checksum = "64d6a0e7bb6503facdcc6f8e19c83cd0bfc8bbbd268522b1a50e107dfc6b972d"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 36.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
- "sp-version",
+ "sp-version 36.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "frame-system"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043790fff021477061b207fd6b33743793b63fc64a583358956787229d039717"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 37.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-std",
+ "sp-version 37.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15afc91c7780e18274dcea58ed1edb700c48d10e086a9785e3f6708099cd3250"
+checksum = "10fb34e948ce86f8e2ceb04d25a0edaa26e308150b6b7c8ce0cbb0e4cd814131"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9e2b7b85e451e367f4fb85ff3295bd039e17f64de1906154d3976e2638ee8"
+checksum = "475c4f8604ba7e4f05cd2c881ba71105093e638b9591ec71a8db14a64b3b4ec3"
 dependencies = [
+ "docify",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 34.0.0",
 ]
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6ba8b36a52775ad39ccfb45ff4ad814c3cb45ec74d0a4271889e00bd791c6c"
+checksum = "ec60be1ddc39bd312496e58b2dd82e5f3d1e0609b69f9586ba6967a36453e495"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -5700,38 +5767,38 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "37.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f06f25f3b298799dbc20f7ffd40e667adc4fbd664cbb23ead5f7bbda52407ff"
+checksum = "5c7167112db20b1a04f24ee9ed383219c1eb15cadea59aa6eb9b9ef5b3f7daab"
 dependencies = [
  "futures",
  "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "35.0.1"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9a252b1e03418e99c18ff6e2d4d9748d195395ed3749c8bfd9ca2c7530a43d"
+checksum = "56fea3dbcfc8b40f4516bed401bc6b4501e82d1f0b5d03e7569a3c836248fff9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -6346,9 +6413,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestra"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92829eef0328a3d1cd22a02c0e51deb92a5362df3e7d21a4e9bdc38934694e66"
+checksum = "41f6bbacc8c189a3f2e45e0fd0436e5d97f194db888e721bdbc3973e7dbed4c2"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -6363,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1344346d5af32c95bbddea91b18a88cc83eac394192d20ef2fc4c40a74332355"
+checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
  "indexmap 2.2.6",
@@ -6394,172 +6461,163 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f726ebb59401c1844a4a8703047bdafcd99a1827cd5d8b2c82abeb8948a7f25b"
+checksum = "6847af5ada683672e4ba5307edd30935b523b96ddd3e6c0d9ae538967e7b6e72"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e806842bec955190ec64f8b2179f74f5355137c4cadf04f3269e6196cd19caf9"
+checksum = "16cf98e523678604f17e784986e789f515bb367dc5cf41f8f966b934ea2fb9d5"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100a180dfbf30a1c872100ec2dae8a61c0f5e8b3f2d3a5cbb34093826293e2ab"
+checksum = "b8aba8d3470ea8ca27a8d3fecce2896094d22e7b3109120b01d0d5d2553f5a6d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
+ "pallet-transaction-payment 37.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "37.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79ef6a7763fc08177f014052469ee12aefcdad0d99a747372360c2f648d2cc4"
+checksum = "cd34007f64b1159232feacc431ae88b8319e16e594ed6ffc2c1a10ecf6e0ad64"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0861b2a1ad6526948567bb59a3fdc4c7f02ee79b07be8b931a544350ec35ab0c"
+checksum = "a2b4c3fc3c5af69af275ee8f1fc70aa73d0633b0cd818c603a2e8b483d4a9ccb"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c3666a476132f5846fe4d5e1961a923a58a0f54d873d84566f24ffaa3684f"
+checksum = "e950b8368ef4af6af91d10061d5fc587ee92ed360e4b5bc32454a68842ccafe2"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-authority-discovery",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38885846dbcf03b025fdbd7edb3649046dbc68fa0b419ffe8837ef853a10d31f"
+checksum = "6ddfa02ecfdd0bfa4841dc16ebd3bdd0d1918751b845f4b36b29c01bfaf75b5b"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23d2d814e3cb793659fcf84533f66fdf0ed9cccb66cb2225851f482843ed096"
+checksum = "cf4cee370246a2a8fa7d62b02b96febde7c8b09d18c9b8ce3a35c20a142379c8"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-babe",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af34fa3fb6a0abe3577e435988039a9e441f6705ae2d3ad627a23e3f705baa2d"
+checksum = "5143d9c729fe3f02a3ff8d9800dd538717a35f2738aa35828347a060251f41ca"
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-tracing",
 ]
 
@@ -6570,24 +6628,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878e240962d3887f0e0654ac343a18845adb95ad493c9d4d5e803c015d4a4c3"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
-name = "pallet-beefy"
-version = "36.0.0"
+name = "pallet-balances"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715dfcd1bf3f1f37af6335d4eb3cef921e746ac54721e2258c4fd968b61eb009"
+checksum = "267f2b4c64e06d340fab1e48267e815dc2afaf8e6da16369b26b5c9e1e65f1aa"
 dependencies = [
- "frame-support",
- "frame-system",
+ "docify",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 39.0.0",
+]
+
+[[package]]
+name = "pallet-beefy"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02e01c97af95523cc344f05f3c418de43de7d6bc89bbe1e8a640e773146df4"
+dependencies = [
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6595,22 +6669,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "36.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d70c6f872eb3f2635355ccbea944a4f9ea411c0aa25f6f1a15219e8da11ad2"
+checksum = "ebe1ff4ef6dd47ffa01cc390e5505491f65527852a8fe306ac1f82ebb41ee5e3"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6618,111 +6691,105 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus-beefy",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0566499e74ba4b7ccbd1b667eef0dab76ca28402a8d501e22b73a363717b05a9"
+checksum = "5b025a04d02a33335672b144d58a824ca25c45848867180dbc416618f43d3408"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0d652c399b6ed776ee3322e60f40e323f86b413719d7696eddb8f64c368ac0"
+checksum = "1ce40525635682724f4ed243f6be36951df424b24703913fb696d6933e1db55e"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e351f103ebbdd1eb095da8c2379caccc82ebc59a740c2731693d2204286b83"
+checksum = "6ac635059b34dc038781c6d8892aa90327ec2491d4afdcace97e6d66e5ca9da3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f660cc09f2f277a3976da2eef856b5c725ab7ad1192902ef7f4e4bafd992f04f"
+checksum = "0e680a751ac8ea4a820096b9b480457a10abd5ce495e65c24457993ad846d4c0"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-session",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771bf7f6c76c3ea5e965fee0bf1d8a8c79c8c52d75ead65ed3c4d385f333756f"
+checksum = "95b3d561c8e207ecd55cd77d040444f1525a7f6246c5f46a8e7211013ae04b8d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -6733,12 +6800,12 @@ checksum = "3e6989ac82690f981959b0d38ac6d6d52fc06bf00a035548d62b9a2e9c220376"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
+ "frame-system 36.1.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-balances",
+ "pallet-balances 37.0.0",
  "pallet-contracts-proc-macro",
  "pallet-contracts-uapi",
  "parity-scale-codec",
@@ -6748,13 +6815,13 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api",
+ "sp-api 33.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
  "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm-builder 15.0.0",
  "wasm-instrument",
  "wasmi 0.32.3",
 ]
@@ -6785,66 +6852,63 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9033f0d23500bbc39298fd50c07b89a2f2d9f07300139b4df8005995ef683875"
+checksum = "755ac1497eb1b7509f501fabe1f6d8694b8e316aa10c3987f470a2fdeb4e597f"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0596ec5ab55e02b1b5637b3ec2b99027d036fe97a1ab4733ae105474dfa727cf"
+checksum = "ff872d2b23db76b7fc47f4ff20d1a3b713b56367b6c2c9560662213ddd2be354"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccd68a2bf5f2dfda2b810cbe1a779492d4c2e99338989fede4389d412ae325b"
+checksum = "4270bbcd896cc6aa04e0bbb07795b715b5320eacca6f46e7c705c0d70cf66357"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1090fdc6ccdd8ff08c60000c970428baaaf0b33e7a6b01a91ec8b697a650a3"
+checksum = "b02a05136d6c5b46fc4963232ffc2069d444100c79fa524627b307fcaea78cd2"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
@@ -6852,326 +6916,309 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93475989d2f6900caf8f1c847a55d909295c156525a7510c5f1dde176ec7c714"
+checksum = "cd65dad4b4de7ec4b0d1631d1e8ad8766eaaa0ab4e871ec6c73a1e894c68afc9"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-system",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9320d95c95e2d4d3ee24c9292b4ee8562ecb724b985613cfa7f274912bad2c9d"
+checksum = "b619d7819e43ff1cc6201fb4cf73d6b65f6b6975c1014a1d73ac88e60986b19c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155f4f762513e0287320411415c76a647152799ad33db1785c9b71c36a14575"
+checksum = "283f467fdee4862f2fcb7ae354c0380e8e763fc465b6b7c560950aa0cce90731"
 dependencies = [
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8244b686d5cae6a8af1557ed0f49db08f812f0e7942a8d2da554b4da8a69daf0"
+checksum = "78a9db737c0ad83212dd874658194b1be7d9cb3c093599aa02573645f9b991f4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4555795a3e0e3aa49ea432b7afecb9c71a7db8793a99c68bd8dd3a52a12571f3"
+checksum = "e83fd8ea40185db968ecec0c4782e3cdf9a788ad4fc4a5870eeb0d0981de2680"
 dependencies = [
  "enumflags2",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa761292e95020304b58b50e5187f8bb82f557c8c2d013e3c96ab41d611873b0"
+checksum = "be560a30bb7b6e829c9827edb10d1e30facbc923d4fd9ee86476e82eecdda27d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b183880ad5efae06afe6066e76f2bac5acf67f34b3cfab7352ceec46accf4b45"
+checksum = "5e0bd6b183d5bb4c33693c47d8012bb1026b88fff49588dcf5d320a3117f2b8d"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34006cf047f47edbef33874cc64895918e2c5d7562795209068d5fb388c53a30"
+checksum = "aa2168417fce51f72b11973f0bb9eab9bde44e4bbad4fc55090e53255e9104b7"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e65a37881d1998546254a5e50a1f768b3f82deabe774e750f4ea95aba8030c"
+checksum = "0043ed8838d63b195365119311cef59e2cf32f7a7ca55128a4ae1f9fd80330e2"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8ccec82827413f031689fef4c714fdb0213d58c7a6e208d33f5eab80483770"
+checksum = "e82afef201023849dc5d65b6793d4c5f58d91cad42a0c552d1308232dc281d0a"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be58483d827602eb8353ecf36aed65c857f0974db5d27981831e5ebf853040bd"
+checksum = "b836d56979a4cd33b68bca09ea34bd0eb524fad8711cb6471ec84a5c3318ea6f"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77cba0e15749c8de2be65efffa51e02bd051b4e6fcf23360d43c3b6a859187c"
+checksum = "9e5cd85ccaeed4526c5165fa3b66d1458404ce3525d99da22060654edb98fc03"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f8c994eb7298a394b58f98afd520b521b5d46f6f39eade4657eeaac9962471"
+checksum = "d192e723eda9ca952ac184f9cd403e5aa62fa5bc85ac3e1c3c46b65b5923c7a2"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ee599f2861e55fc6113c01e9b14d6e85fda46bac36a906b5dd5a951fa0455c"
+checksum = "b0ccd27fa44dc3d48287bc26094c4a7c29983eea415d2d2862d5ffac1496e0d7"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "pallet-bags-list",
  "pallet-delegated-staking",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-runtime-interface",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2906899d8f029780f0d9da77b90ae86f42bcfda5ac402c931406cd84852012ed"
+checksum = "3c7648bab22c3e941124d3f814e3afbdc4287510241fdda7ca626370c796cd4b"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api",
- "sp-std",
+ "sp-api 34.0.0",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4859e7bb2af46d2e0f137c2f777adf39f0e5d4d188226158d599f1cfcfb76b9e"
+checksum = "7b364e0756f83bcdfd69fd3255a8088f9f048223850f7b86a42742c2e667c694"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4351b0edafcdf3240f0471c638b39d2c981bde9d17c0172536a0aa3b7c3097ef"
+checksum = "f327028dc9ad84f9b5751575f8886f18117aa9d09e5ade98d0bd340c6a6717c0"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-grandpa",
  "pallet-im-online",
  "pallet-offences",
@@ -7179,225 +7226,213 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-parameters"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d9a81a93202105a660e6aa3d3f81638bdd109ca0497f3e528529cd52d034db"
+checksum = "ad6244519de5c956f37f6d34ca2cbbd00e8511ec03e65f32f9e18e9ae39137af"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ac726abc5b1bcd6c8f783514b8e1a48be32c7d15e0b263e4bc28cc1e4e7763"
+checksum = "f1d77b400c54d7d6645a768a62a430dba851e553d9eef9376cfa1ab0e13acf13"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e12680e176607815a78a0cd10a52af50790292cb950404f30a885e2a7229e9"
+checksum = "728a6f11efebb88d9c64fa3335fb376d3603302ee46bbbe36fff8e1d0e01d0d4"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ea8d386ed5737e859470c43cbfd9652c81398cad29e03ae7846c21aaee4c6"
+checksum = "afc2be6163035e045cd82932ae4fe0747207578ac176032119752fd592a5e1cf"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24d4131bc79fee0b07550136ca6329faa84c1c3e76ae62a74aef6b1da0b95b4"
+checksum = "769e3fe4e7445d095814447961d674a01b5feea0d07424ef82ef844f12d8e9dc"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c906a9c4573eb58de4134ec7180bf12c6769df2b9859dae8adcbc5fce78add"
+checksum = "77142a71cbc241ebc5ec11d65868379b7d5440e07ae7545f1bfd5933485f1a13"
 dependencies = [
  "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa61642f7bdc1a393798aa1ff67bb8c29f8f184b6fce165e1079010d446a1e29"
+checksum = "3a9c14b36f689daf3d2110be82aa64f55f2405742f148a7f24187c5d88fb4648"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170d6aa191197d3f50b1193925546972ffc394376ead4d2739eb40909b73c85"
+checksum = "ca20e5a34daccd584fa00e2239113cbb7e6097d03064a8e7dc4df0640ac8dfce"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c92b24c911c2cfa5351616edc7f2f93427ea6f4f95efdb13f0f5d51997939c3"
+checksum = "84da59cf6db5db9a4424a5967787bf4ea20bfa903988a2438429c09a48365acf"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
+ "sp-staking 34.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd02aaf5f10734670346677042ece94fae20dcd5436eafeb9b429d8d6d5b6385"
+checksum = "018aab2ea95d8aacd1d6e7aab408a0bef45087269b00646a74efac859952175e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b60b1d726532317f9965bab4995aa49b73f9b7ca3b9a0f75d158bd84686c5f"
+checksum = "bbfcfe8e812f5e99f09526897955b4e1d93c4032f5303880a222001f5534c6c6"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "rand_chacha",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbebdb060417654f215fc6f03675e5f44cfc83837d9e523e1b8fd9a4a2e1bdc2"
+checksum = "e59824a9ca557a64c4ba26331a2db84f91610e75620a497610287a16edfb52d7"
 dependencies = [
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7405,11 +7440,10 @@ dependencies = [
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-application-crypto 38.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
@@ -7436,89 +7470,85 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3350ef1795b832f4adc464e88fb6d44827bd3f98701b0b0bbee495267b444a92"
+checksum = "3741b83293a288854283ea9baedba017ae8b34d7eff0f6166f3fcbde2c01228b"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 34.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "37.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07f8626f4ff62ac79d6ad0bd01fab7645897ce35706ddb95fa084e75be9306d"
+checksum = "d7bcdde046a530b78cf8caa8faef67208a38093658f5fa3668b183967df4ac82"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd2a8797c1bb3d3897b4f87a7716111da5eeb8561345277b6e6d70349ec8b35"
+checksum = "c82e375c0a4c4ed079ae49bd2693548bd57178273b37631bcd7e817242d0f2b0"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae789d344be857679b0b98b28a67c747119724847f81d704d3fd03ee13fb6841"
+checksum = "d301332166bded1fb86eda22846287de6c7313c15dce87535aae3c956f5f2c9b"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "sp-storage",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dfec7872ee9e071209ae860094569745e8bd47564bacdba739256ee52cf78c"
+checksum = "cb28f1cf5ded9cc71fe04eece85be06482c1b6544facb1092ebb18eeb3e23e2e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -7527,159 +7557,169 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fb6114223c8d967c3c2f21cbc845e8ea604ff7e21a8e59d119d5a9257ba886"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 36.0.1",
+ "frame-system 36.1.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
-name = "pallet-transaction-payment-rpc"
-version = "38.0.0"
+name = "pallet-transaction-payment"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82898085607c7b00ef20fdce7c621790bf2b644c134918a172fe0a8f7f08e6c"
+checksum = "7d6b4889a0a8565cf0d6ecf3feef787c18ad2c529add4d90ec896873cd422eec"
+dependencies = [
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+]
+
+[[package]]
+name = "pallet-transaction-payment-rpc"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2496ae1bdf86dd0aeb213d33dccd0edb4abfcead660ada070c81b254ea2cbf75"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bad1700ad7eb5ab254189e1df894d1d16b3626a3c4b9c45259ec4d9efc262c"
+checksum = "1879d1f608f565d590fc7520a8d9977b868a412910f6381a5ebfa45acf8abcfb"
 dependencies = [
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c502615bb4fdd02856a131cb2a612ad40c26435ec938f65f11cae4ff230812b"
+checksum = "dee7b2c3dec2979b0ea7bc33f01d78d12ed58b556011c52513dfd422342df8f3"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3238fe6ad00da6a137be115904c39cab97eb5c7f03da0bb1a20de1bef03f0c71"
+checksum = "db53b324a0d0f078b5e61434fb3f2f4a89d81481dfd799fa4a71d054b441672a"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f7f0f4fe5e1d851e85d81e5e73b6f929f0c35af786ce8be9c9e3363717c136"
+checksum = "271f52d5ec90583ce7bd7d302f89b9ebabe1a820dc3e162fc1e5b14889f3b12c"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "35.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4f27640279229eb73fde0cb06e98b799305e6b0bc724f4dfbef2001ab4ad00"
+checksum = "a69f9fedf59efa21db7724c78627e4118e74621e27d90f9b5fa96ad4cff076f3"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7409458b7fedc5c7d46459da154ccc2dc22a843ce08e8ab6c1743ef5cf972c"
+checksum = "10a8c373e1c15eaa72fada061ffc486d81ff8bdb253ce3d569908c97ed40a89c"
 dependencies = [
  "bounded-collections",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f177a171203cc0bec3cff1bdd5d3b926abfbd0ecf347e044b147194e664f717"
+checksum = "5629e0639e2894d9a647a5146f63b219d7317f34196e91c42ab384f533cd999e"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
 ]
 
 [[package]]
@@ -7698,7 +7738,7 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-benchmarking-cli",
  "futures",
  "jsonrpsee",
@@ -7726,14 +7766,14 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
  "staging-xcm",
  "substrate-build-script-utils",
@@ -7755,11 +7795,11 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-utility",
  "docify",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -7767,56 +7807,56 @@ dependencies = [
  "log",
  "pallet-aura",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-collator-selection",
  "pallet-contracts",
  "pallet-message-queue",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
+ "sp-genesis-builder 0.15.0",
+ "sp-inherents 34.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 37.0.0",
  "staging-parachain-info",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "parachains-common"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9319e656eebdf161666e54a4d8e24f73137f702f01600247f7be650bc4d46167"
+checksum = "91304aa1eb95bdea1471bc3994fb8cb30a8d913bdcd2abe59a70abfaf3e49abf"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-collator-selection",
  "pallet-message-queue",
  "pallet-xcm",
@@ -7825,12 +7865,11 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
  "staging-parachain-info",
  "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm-executor 16.0.0",
  "substrate-wasm-builder",
 ]
 
@@ -8124,16 +8163,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "polkadot-approval-distribution"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d39d6552d00ade2d668b8171aa7d6a1f5da4c7ebff402b5a9877b5d1e45b4e"
+checksum = "c53b0e4c6bf09e87b965bb10a807610fa1190b6f2b955dd3ba3862744e331aec"
 dependencies = [
  "bitvec",
  "futures",
@@ -8152,9 +8185,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0a8b5280959524f84b09c27ef0dbceeced6d19537f8fd43d03a08414f8b93d"
+checksum = "c29fdff2d3e2190f9663960aa69a081318151bca946aa2a7224cd73119b9e908"
 dependencies = [
  "always-assert",
  "futures",
@@ -8169,9 +8202,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "15.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfe520a9c8dbe6c5db06c0b919c53441927babc1c02b9df76718fc4b80c5c4f"
+checksum = "fa75f0cbf5d58995bc6e3db3e77104eb79ca30675a5ad948db878be6af4428c3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8194,9 +8227,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727f02306a3a51eb0b8efca3e1e14c5efa2daf921c9be7c46d9c5d68670a9b51"
+checksum = "f413cb594c14203882ab6ef8c627add94edf2f7ec57f8b5f377731240ed093d3"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8228,9 +8261,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141a62da626bba7c4a29b8e5d20a975efa6439095a352ebfc47f068e4dfd82fd"
+checksum = "7ed099a74eaf2c0bb4dfd959846fcb712248e1d5bb9850e2e596aba23c871392"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8247,19 +8280,19 @@ dependencies = [
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-build-script-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75bd07cc8a0bfabe6464d40072e30bd87f52730fbc26c733f0a8ffa97918c0a8"
+checksum = "e0f5f3a39decbc74ee4a95e13d8bbf7af8a8c5b1774b3096d7e20fb1bcff1ec2"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8272,7 +8305,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -8287,15 +8320,27 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
 ]
 
 [[package]]
-name = "polkadot-dispute-distribution"
+name = "polkadot-core-primitives"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c49e68add45aa6c2b85e97f0d09b81f26b1428117bdc9284eaa74a1eb63daf"
+checksum = "e2900d3b857e34c480101618a950c3a4fbcddc8c0d50573d48553376185908b8"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime 39.0.0",
+]
+
+[[package]]
+name = "polkadot-dispute-distribution"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28a79ad565b5b028f76a818920d31828e3685a09c21e44f5a96e504e1d8062"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8311,7 +8356,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8319,24 +8364,24 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a39a54a269817e09d602b4e9c527905f9e367ff7c6337b1b3e1e048515f6b59"
+checksum = "7749cb866574f9d322b698cc81b129f976e139e516b150d1536ae0e557091966"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
- "sp-trie",
+ "sp-trie 37.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b56e8fe08e4ed30af0d296870b12b5a7411695f2b79b3c5842d04b9a347200"
+checksum = "2726a2d1d7bd076dfd53a43c3c9c49592eccd9fbf061a41bef9908b4b95fddfb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8348,7 +8393,7 @@ dependencies = [
  "rand_chacha",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
@@ -8357,9 +8402,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "178b92197936c23ae8a936ec74b83a15a9fe0978c7f3de677db141ba9c524a63"
+checksum = "ca4158105cbcde10237e89e8f8cc594f9f0d3a4c72bb924957eb9861c0591285"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8381,9 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869534f66d5a38443acf4b9fec3a4919f59f293e6fdee4177cd7cece1c4a85ef"
+checksum = "818cbcf63a44e83309799ab39e718db03931c42a7e73934971f2126d0220fd54"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8400,9 +8445,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3629b2d93b5f152bc75437fb68326ebf9267885ff89f2abede9b8a050e9288"
+checksum = "219f36432024236721979dc93fad0645dd05edc11fee723b4a63275a1e008aae"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -8424,19 +8469,19 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8487c45eedaaf535ccc78bf4f459eae9443c4c9cfcca31dc3838950f3a3426e3"
+checksum = "851022666104502b0fed95603d17437cc843aa45e806379d91014ca2553e13f4"
 dependencies = [
  "bitvec",
  "futures",
@@ -8457,9 +8502,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493dff8562ce2675dbb0e5c8594e145085a4536de435f5061f577bdaba2195e"
+checksum = "90dcd67ff8d5adf6c4b0906e947549abd74346a1ef6b586a4ac0cb677c1e557e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8478,9 +8523,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5946d61086be5096e8dafd731d0881fa41e12f21a1f3a8b9d7ff6f1294914b98"
+checksum = "ee3097c01b77a1a5b87a861a6107b3babb71c3e68aba60b9523ebe5d1f3eea76"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -8494,9 +8539,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "15.0.0"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389b6d8da9a7cf825f97ff4da4ef754a1371de0358e896fbec973f4ff1dfe011"
+checksum = "09d1495d2638dc8316f334deb18333af3ae88e8bf9fc8dfcfc52c17419342174"
 dependencies = [
  "async-trait",
  "futures",
@@ -8508,17 +8553,19 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
+ "sp-application-crypto 38.0.0",
+ "sp-keystore",
  "sp-maybe-compressed-blob",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29086798f24839c9dc1c8b080ffc68bbfe2a5fdc5f29de557b9d224a45011094"
+checksum = "0e8d8d2dfcd6fbcbc074742e0eef1d9d001fdc63b03c63127e8861602bed9b1a"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8531,9 +8578,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c8bcae78a4562bc8b3b786e08cb1b3c96c29554da7d57b6806a6723b1540b0"
+checksum = "b547ac1ad390fbe26b37e118b3d8e983de09ce9bf3795f8f5c3ad78f9a7dba52"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8549,9 +8596,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459e1da76e61c2f5636123ae7c19097067dcc1d07e0d5e77eae4eb87e5cb999d"
+checksum = "bf44bab236987597edf5c7198910df925db8dbfeed94575c3256def5b3e0626a"
 dependencies = [
  "fatality",
  "futures",
@@ -8569,9 +8616,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4d2b44748657a68c8ff2995b0b39609f5186bc4b07040ebb6b389dbf1047b"
+checksum = "7a659d8c03e9971717751e408ab675fee4ce58c6172c891c704fd910f2aeaa0d"
 dependencies = [
  "async-trait",
  "futures",
@@ -8580,22 +8627,19 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 34.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "14.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756205c36293216422775c6fa1be9fc4bdb99fa5cafd86b96e7feae13e669e79"
+checksum = "46c319984f0dc60568cd9386040306ce097fce852d7b259ca36140d637359af6"
 dependencies = [
- "bitvec",
  "fatality",
  "futures",
- "parity-scale-codec",
- "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -8605,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f090dc90bbe0b452a57a3129b53a6129e357ff4607e9db27a54b291d7a747b"
+checksum = "fa4e214d8222bc616135440f9d8dd2df482de010d64dff6adf8bb0807023a5ee"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8624,9 +8668,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea57cb8ce66c2952b87b2476b46d6316ae58342f198abd09c391827ed5402d"
+checksum = "fbc89ee7b9c628b43ee40f1a1c9ddd3c1e2556340fa2694b6464ff85aef421a7"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -8636,12 +8680,12 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 15.0.0",
  "polkadot-node-core-pvf-common",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "rand",
  "slotmap",
@@ -8654,9 +8698,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6483e6db611d96b14deb298bcf877c44905ba2b45207183d62d0fda9c2fcfec2"
+checksum = "81e863c1f1bea82b1ef87e7344cee6338073803077558437dd3897809c78eff2"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8671,9 +8715,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "14.0.1"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0eca24abc74c0c3f02f9986edbda12b3e8b6d294c39b238cf39e94e246aa2b9"
+checksum = "ff1d2bc3b8f462ac9754aa618e8f14fb86d4d9288d19fc198ecf27102cfe23c1"
 dependencies = [
  "cpu-time",
  "futures",
@@ -8681,7 +8725,7 @@ dependencies = [
  "libc",
  "nix 0.28.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "sc-executor",
  "sc-executor-common",
@@ -8690,7 +8734,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8698,9 +8742,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0024b2f4e4a03e4fda348183bbfe5eb51dd6e90b57eabc83596ee4d0079fd0e8"
+checksum = "07dae67e19cc80d20445f72c0e573a3e3d6234500470e39b4c65b837a66ef1ec"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -8714,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671c3407a7e325264af798664ca60c985873c04f54f53cc8f02aa81512fd40a"
+checksum = "3f966ae24ad519e6207465224a1e36058d516bd2f746c6646e2e8ffd48a4442a"
 dependencies = [
  "lazy_static",
  "log",
@@ -8734,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae429c6a40f782a615d7ec863c4eda83c36bee5f6b542bcf86f754342f97b5a"
+checksum = "137e3c41037c7be62b2583ccd6057a3f9a8f63cb57bd46a197ebf7fc0edcca0e"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -8754,9 +8798,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf88dcc39ac21e12a65c255707b89933ddf3dadfb2c422d9f0fd8ff644229e77"
+checksum = "dcebfae137cf15caa2d53e1f64f0c4246d6f9e142ce0b563e5e9f6f3eb23e294"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8773,7 +8817,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "strum 0.26.2",
  "thiserror",
  "tracing-gum",
@@ -8781,33 +8825,33 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779833f70a1563ed042d3c6b831a45c5ea0f80caa8f4ede487f7bee3130168fb"
+checksum = "a4e7e0b99d1f5fdadeffd8215cf7191620cf97fdde07540444c80afa16c62911"
 dependencies = [
  "bitvec",
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
  "sp-maybe-compressed-blob",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a338e574c2416135b0004ebef226be22db13c44532e2a0f33b67648afb3ca12"
+checksum = "1f679dd4c70c007707eec94c6500b128af5e26126ab3c5716e967d25b9a92c11"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8816,9 +8860,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "15.0.0"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0df39c7eef657b1e28917529f0b0c2aa5f0b013f4f298cfb3620b54449f0c95"
+checksum = "5c6dab177b0dbac5654e4476a5bd53fd51088c7a2cbcb615b60b381d8a0ff4c2"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8836,20 +8880,20 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "15.0.0"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a268e05c8c39aeb81b9ad59dfd18a7a711c8f8fa19bf83c75025de25466b7"
+checksum = "3881f06f2bfe1de9643885a861f973bd1e606d6f7775c655250225c6a2846de1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8875,7 +8919,7 @@ dependencies = [
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -8884,9 +8928,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2456c1b2d176550e91e2e1ddb092390b00e20898e5c4fd9b5978d56ab1bbf24"
+checksum = "036703ee0019595aa2d8049c302d98f7ca7fc9e6b3d8005b7fd9f6a3c193048e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8899,7 +8943,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
  "tikv-jemalloc-ctl",
  "tracing-gum",
@@ -8914,48 +8958,64 @@ dependencies = [
  "bounded-collections",
  "derive_more",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 14.0.0",
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-std",
  "sp-weights",
 ]
 
 [[package]]
-name = "polkadot-primitives"
+name = "polkadot-parachain-primitives"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4879609f4340138930c3c7313256941104a3ff6f7ecb2569d15223da9b35b2"
+checksum = "52b5648a2e8ce1f9a0f8c41c38def670cefd91932cd793468e1a5b0b0b4e4af1"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "parity-scale-codec",
+ "polkadot-core-primitives 15.0.0",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 39.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57bc055fa389372ec5fc0001b99aeffd50f3fd379280ce572d935189bb58dd8"
 dependencies = [
  "bitvec",
  "hex-literal",
  "log",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc80e33ff0a7155588d7b6cadffbbad7e8e489c2275f6f49ce61cb5cdfedca7"
+checksum = "8867722db9bc21535a35f1fd919d2608695c9edb5cf59b4f4463c15670a7c1dc"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8974,37 +9034,37 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fdcb41bb21c7b14d0341a9a17364ccc04ad34de05d41e7938cb03acbc11066"
+checksum = "0572bf05ac57526ed10597078e2598cb3ee9ae9b7eba605d222276bbf1cee44b"
 dependencies = [
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
  "pallet-asset-rate",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-broker",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
@@ -9013,7 +9073,7 @@ dependencies = [
  "pallet-staking",
  "pallet-staking-reward-fn",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
@@ -9024,53 +9084,51 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac75b3fea8464e5681b44733ed11cf09e22ff1e956f6703b918b637bd40e7427"
+checksum = "e4636dd0772d838fb2e3c4a54a6530f2921e80d6cde48eba0ecc029e6378f900"
 dependencies = [
  "bs58 0.5.1",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "15.0.2"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb1cf1fa41c64b0b515a33d7bd388c3af0de31e5f93bd4c2b220e408f7f968"
+checksum = "c2fae7580b1a541a810e3602c46086a181a6e8aa2c178f3b6f0a4fb5e0bd9f9c"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-broker",
  "pallet-message-queue",
  "pallet-session",
@@ -9078,43 +9136,42 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain-primitives",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
  "rand",
  "rand_chacha",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
  "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm-executor 16.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "15.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa560fb67981865b895082845c4ec43fabb206da5bf583ec5ef3561a8e3fc333"
+checksum = "0fe2358dece71b78a73e193300f4a8e6b21c10c792a44586d5e4dd965553b5df"
 dependencies = [
  "async-trait",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-benchmarking-cli",
  "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -9125,7 +9182,7 @@ dependencies = [
  "mmr-gadget",
  "pallet-babe",
  "pallet-staking",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -9135,7 +9192,7 @@ dependencies = [
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 15.0.0",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
@@ -9160,7 +9217,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-parachains",
@@ -9193,7 +9250,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9202,19 +9259,19 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-keyring",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.43.0",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 37.0.0",
  "sp-weights",
  "staging-xcm",
  "substrate-prometheus-endpoint",
@@ -9226,9 +9283,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16020ecadd1826ffbce2693ba1490123a0f7ca74d233c9bc8c0cbfc23bb4df2a"
+checksum = "6bae872cdd58ae0086e760f22fbb7e40832cac3c8d7a5a2487de8f9b618a57ae"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -9243,16 +9300,16 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking",
+ "sp-staking 34.0.0",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947e9e3c8f71b9678f39a01f371a808b574823967dd9da187e6f886f5f08691c"
+checksum = "a80c5e2b38fcfdb7756d8a8ca0845e6707b7ee81b151f2dd9d142866f008ad5e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -10183,17 +10240,17 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0874c053846cd50170370d88244fd00ed299d3d3833804f0929371a9ed836137"
+checksum = "27697241f5185ccee6eedf63a6db39a20ce71a5f834632ac78f5b219201c4e0a"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10203,7 +10260,7 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-bounties",
@@ -10236,7 +10293,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -10245,7 +10302,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -10255,7 +10312,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -10263,21 +10320,20 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.15.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 37.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
  "static_assertions",
  "substrate-wasm-builder",
  "xcm-runtime-apis",
@@ -10285,19 +10341,19 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef330dc0657ac9e4ff93ff320e2ee1a120493bceb91010c7ef7b08fe8e27950"
+checksum = "98cc34894f6b251d166f2d607a61b1d5deef73d4ef6ea85e0074db3f0e366a65"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm-builder 16.0.0",
 ]
 
 [[package]]
@@ -10621,9 +10677,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae99d03b5cf657754241180c4aedd14c4851a08f3fa56814106b3cc02083d2c"
+checksum = "d36f30d71de4249c90207b06b8a60ab1926df2c10c4d668f7d1b5a2bda004d9b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10640,21 +10696,21 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c31a124aa02343a17cb86cc714bc2b66ce18c7f17530178767388de8a37b152"
+checksum = "bdef7ee4dd39a41957eeafb99c55749f8065a72f46c12e209ed15f4669360a6e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10664,36 +10720,36 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6345fb862e10aaa7d88d6689a7c247448c40ae465253c83566dc76a17ec1426"
+checksum = "f666f8ff11f96bf6d90676739eb7ccb6a156a4507634b7af83b94f0aa8195a50"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04100ec7ff9cf1f2052b05086c77cc216ff7268b8c4fe41007de420bc1f70be"
+checksum = "9149a7ee8a4a799feb3ed581a288a0ce6ede42fb8b1997806f6a29997cdbd9be"
 dependencies = [
  "array-bytes",
  "docify",
@@ -10710,10 +10766,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.15.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-tracing",
 ]
 
@@ -10731,9 +10787,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a50b5a5de473b38de8a909b125b9747a30158900159e59251bb716f80d6d22"
+checksum = "b37e08bde78fa7bdf3e30682a6840236de49d2c11960535eb9a9a1a87a0fd3ab"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -10765,17 +10821,17 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 39.0.0",
+ "sp-version 37.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "35.1.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb517f4418644aeefd7c29bbe34bfc56ba8b5ea56e0b661a48a4d4d6afef40b"
+checksum = "e73f1673cdfe658c4be6ffd5113b71c0de74616717e604455dcfd29e15781729"
 dependencies = [
  "fnv",
  "futures",
@@ -10785,25 +10841,25 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-database",
  "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "sp-statement-store",
  "sp-storage",
- "sp-trie",
+ "sp-trie 37.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3c685871877f39df000ec446f65fc8d502a7cecfc437cdac59866349642dc3"
+checksum = "1b3a8a704ef66326a1f95ae17fe42a10ef55158c738bd904fbc6d4a0e7f9eb29"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10821,16 +10877,16 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2927954d83d4c055a8699cad8ae093fc921ce73694da6773bd06d195e9a8dd"
+checksum = "502b55375db80dea8be1336b203eb96c1e22e7c4fa7782dc775bad71688bb91c"
 dependencies = [
  "async-trait",
  "futures",
@@ -10841,21 +10897,21 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017320849a7fce8200da88ccf07785d461c4d144032788f09eb4316742649a38"
+checksum = "8cde090c64dfcab34347bd5472b40cc608b7395ef2dd1a8403c6c13dbec74c80"
 dependencies = [
  "async-trait",
  "futures",
@@ -10866,26 +10922,26 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
+ "sp-inherents 34.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c28b231f19a90917fde889a5077a796e2f9cb4dc6b62f861a8d859437a54cc"
+checksum = "ec4aea13d44497edd2c240c85a3722c2431eaabf7f6d172891d12908504cab1f"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10902,8 +10958,8 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -10911,18 +10967,18 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-crypto-hashing",
- "sp-inherents",
+ "sp-inherents 34.0.0",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879efb0d8d0bd363d38ca314fbe4c44363dc1bdcab0ba1c21e78d9a68fd4398b"
+checksum = "63817e1b4fe3d772027d8c96eb6231fbada0f79d5626875016266cc7fda69a10"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10930,22 +10986,22 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "21.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddcd779375dc2aa4abfb2ff8e001d0901593b58e5c70e1720472a001fe13105"
+checksum = "09b5eafaff65f0d7f5056d0d05826e5fe3349bc0e4977b538d343f55320a7748"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -10962,8 +11018,8 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -10971,7 +11027,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10980,9 +11036,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "21.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e88abb3353e3ed98bcb8ab829dc84dfdf9d17f5312568bdf2361a1bde7ce0a"
+checksum = "7e2b707ce26b8460afb724a977aabd95617c9758771a8b842c90b9405d4262cb"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10992,32 +11048,32 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-rpc",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-beefy",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c983798bfea80e629ffa4faa7c299f8522d382703cd32f7a299beaf69631586"
+checksum = "a7258d517642944d4e39d11f77a413825349089e01b6f27819f4349932ff07ec"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c6c62a03b54973f1a608a405908af0fe957fefaf77483cce96bd213eee7ed0"
+checksum = "197e67ed725bcad27563c4418254e89e56eb79491cebb278e9926760a1fc16d4"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -11044,8 +11100,8 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -11053,16 +11109,16 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef329f23bdafaeb57e131b81cc479a85b6ecb25e42435b6a6a544d048207685"
+checksum = "6400433a4a8114f5fe7b5673f9332129ac55c71a9f6224c8b2cdf3251a000f10"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -11075,15 +11131,15 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca112d43c7785193362b33aa7941947bb84d65db9187abe72f1f7a969474c0"
+checksum = "97f4aab75d55fbeee7437ed6a127a749014f831f12a0b409a71cfc3a42453ccd"
 dependencies = [
  "async-trait",
  "futures",
@@ -11098,16 +11154,16 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f5767bf6a6bad29365d6d08fcf940ee453d31457ed034cf14f0392877daafd"
+checksum = "963c1ebaf6bd0bc4ab0603c3cd7200ed25230a897a3217928a559fedce6019df"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11115,14 +11171,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
  "sp-externalities",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -11174,9 +11230,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c3751acd690bc469b859d0ad899b076642db9b107e31c28cbd99749b6ecb91"
+checksum = "e6dcfaffeeb2d662a26f84706132dcfd294ffd71c4077d0b4f92a6f54db184f6"
 dependencies = [
  "ansi_term",
  "futures",
@@ -11187,19 +11243,19 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267c8cfaceaeecb25484bad8668c17036016e46053a23509d44486474dbf44d3"
+checksum = "4ebd4b5b5713006117641c049cb082e8a439dd6ac5e7b171e5cef5ce1c9f8af8"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-keystore",
  "thiserror",
@@ -11207,9 +11263,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a72a92dc72572a0facd73b410855d7f6edf38b32aef46c4798c74f25e595d5"
+checksum = "04ac673840824d0357dedee5b952440b469d11f48314ff52ae59049aee7e376d"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -11226,20 +11282,20 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus",
  "sp-core",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04be75f35cea819bae84be99cde138872b17494acf0e54f5f0ae8b0ed3fbe51a"
+checksum = "6a4923392c50d67849efca43d1a2601f6150c79fb8ada3383c26ce1b4f28d1af"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11276,7 +11332,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11289,9 +11345,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec0c3c5629a418fb26b56963d40c5ca3fd02dd94eb5753e9eb72cea5c2eeb2f"
+checksum = "11a8bbc9d2600f34d021796bdffbb20bdf4723f98ff3126c765b4c9363bef564"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -11303,14 +11359,14 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae1836528495b6aa5140da39ed0278f5086c21ce530c37964db1b2e2c101ab1"
+checksum = "2dc2ff366c09b8aba9b0bfd04b991508788203a28da0c66a32625cda7ae8015d"
 dependencies = [
  "ahash",
  "futures",
@@ -11321,16 +11377,16 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-network-light"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e6deda277664336c26ea251cc1ebff7a165df0e3ad4ae23113380d9863ea40"
+checksum = "18efef00b71e1a7060fb92dcc433ed4bed625a803b074e0bf4b4cf6e1d90384e"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11344,15 +11400,15 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-sync"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9ab31b84534c487b9fb84e83db47890fcbd350f354b1e6484892d3d42d0020"
+checksum = "628881aacdd36235d2725a7ecb13d6445c76ad470ed6e6473fc58c6b98a2417d"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11379,7 +11435,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11388,9 +11444,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2eb55e29b0ca52ad3e209fe569b72dfe6b44cc1da7d722446d5a8333dff8e1"
+checksum = "8661c677deb9159c291a4dccbdfeba3e1fe5106caea0936fb70d3765a163aa8e"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11402,7 +11458,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11426,9 +11482,9 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "37.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d77ad5f923ec4183d6b31c7432fdb56d12ee69cad2cff17d4a39caf933bcb"
+checksum = "2f0fce257906e8a6f2ffbabe64ce9739ef0e18f272f61e759c975446c752cd74"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -11449,12 +11505,12 @@ dependencies = [
  "sc-network-types",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "threadpool",
  "tracing",
 ]
@@ -11471,9 +11527,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "37.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9cb792ddb5d0c3df89018e80290de4c769315fa59271bda0a0d29b2d182fdc"
+checksum = "3ccc910a40803287c65194e232d99bf6e1f9200b04f8dd91433f298687b8bf3f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11489,24 +11545,24 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
  "sp-statement-store",
- "sp-version",
+ "sp-version 37.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b8adf62a207985cf7534abf0d940b335fda0a68eb902da05b7270ee30a6293"
+checksum = "575a098a1c59d15bec2df388437474334b76c512e9dd92b0f275801906303354"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11518,8 +11574,8 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 39.0.0",
+ "sp-version 37.0.0",
  "thiserror",
 ]
 
@@ -11548,9 +11604,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4242d30df623f68d5b937ae264cce85e734c35922e0bf196d7a59b8e7f7843c2"
+checksum = "934087c0aae2642327e07070ae3739ae82bbadaf876fadcff0c9b19c37a87ada"
 dependencies = [
  "array-bytes",
  "futures",
@@ -11568,12 +11624,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 39.0.0",
+ "sp-version 37.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11581,9 +11637,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718b7e3a3963b09c2ab18ce13dbc43c0afa8b53169b67372fbcc4c4147b77e05"
+checksum = "fd9eb103478c93e3a9325fb9c07d2c6a507cd04934954c930fc33a1e0791010b"
 dependencies = [
  "async-trait",
  "directories",
@@ -11621,20 +11677,20 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.43.0",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11672,9 +11728,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fca6421f003249095557d97b674a27bf4bbf1f301406eb04c42878a43fc715"
+checksum = "9dd5f8003789ec2c28d49fc496ee5fcc7f6e94dcd3ee8a7a375f2e50a3bbc5db"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11686,15 +11742,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-sysinfo"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c00ab3d8f51c1905cc3c53cf441b9d94403c67f27968002ff7765248b0f3e6b"
+checksum = "c2ce11152bd7a2b01713e71de71a5610067bd1b3509aa207e3d87f5ee53dd328"
 dependencies = [
  "derive_more",
  "futures",
@@ -11708,15 +11764,15 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "22.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fc8e8ad7f84f2ca864ee361b6207fe21e18c8182c60f209732b2a7c0dcbd31"
+checksum = "3b59589eadf05088221cc60b6d9f68f89208262ae9b1e4fb8704eefe7de48845"
 dependencies = [
  "chrono",
  "futures",
@@ -11735,9 +11791,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61151f2d6b7ce3d7174484414dbc4e2f64b05a144c8f0a59ea02284e6c748a19"
+checksum = "1bbb3394a7ebed811150ebc00e371af9436b43dc214b97e79e3839ae987953bf"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11752,11 +11808,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11778,9 +11834,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800e35d0d2f2b8e17170ec961d58756fe7891026b19d889be388b9585cb12f90"
+checksum = "f716ef0dc78458f6ecb831cdb3b60ec804c1ed93313d7f98661beb5438dbbf71"
 dependencies = [
  "async-trait",
  "futures",
@@ -11793,11 +11849,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11806,9 +11862,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de6f60df6706970061e225e87d77aab9a764b258fe151b896a700419bc6b9d"
+checksum = "f02936289a079360935685eee5400311994b25e9edb2420a3c4247d419a77f46"
 dependencies = [
  "async-trait",
  "futures",
@@ -11817,7 +11873,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
@@ -12312,15 +12368,14 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d67aa9b1ccfd746c8529754c4ce06445b1d48e189567402ef856340a3a6b14"
+checksum = "5e34f1146a457a5c554dedeae6c7273aa54c3b031f3e9eb0abd037b5511e2ce9"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -12533,12 +12588,35 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime",
+ "sp-runtime 38.0.1",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.42.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 36.0.0",
+ "sp-version 36.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbce492e0482134128b7729ea36f5ef1a9f9b4de2d48ff8dde7b5e464e28ce75"
+dependencies = [
+ "docify",
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro",
+ "sp-core",
+ "sp-externalities",
+ "sp-metadata-ir",
+ "sp-runtime 39.0.0",
+ "sp-runtime-interface",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "thiserror",
 ]
 
@@ -12567,8 +12645,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
+ "sp-io 37.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8133012faa5f75b2f0b1619d9f720c1424ac477152c143e5f7dbde2fe1a958"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io 38.0.0",
 ]
 
 [[package]]
@@ -12589,143 +12680,144 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4a1e45abc3277f18484ee0b0f9808e4206eb696ad38500c892c72f33480d69"
+checksum = "519c33af0e25ba2dd2eb3790dc404d634b6e4ce0801bcc8fa3574e07c365e734"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf199dc4f9f77abd3fd91c409759118159ce6ffcd8bc90b229b684ccc8c981f"
+checksum = "74738809461e3d4bd707b5b94e0e0c064a623a74a6a8fe5c98514417a02858dd"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "35.1.0"
+version = "37.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27eb18b6ddf7d663f4886f7edba3eb73bd102d68cf10802c1f862e3b3db32ab"
+checksum = "a309eecd6b5689f57e67181deaa628d9c8951db1ba0d26f07c69e14dffdc4765"
 dependencies = [
  "futures",
- "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-consensus",
+ "sp-core",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "sp-consensus"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab094e8a7e9e5c7f05f8d90592aa1d1cf9b3f547d0dd401daff7ed98af942e12"
+checksum = "ce75efd1e164be667a53c20182c45b4c2abe325abcbd21fc292b82be5b9240f7"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ebb90bf00f331b898eb729a1f707251846c1d5582d7467f083884799a69b89"
+checksum = "7a8faaa05bbcb9c41f0cc535c4c1315abf6df472b53eae018678d1b4d811ac47"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa2de4c7100a3279658d8dd4affd8f92487528deae5cb4b40322717b9175ed5"
+checksum = "36ee95e17ee8dcd14db7d584b899a426565ca9abe5a266ab82277977fc547f86"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "20.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b277bc109da8e1c3768d3a046e1cd1ab687aabac821c976c5f510deb6f0bc8d3"
+checksum = "695e79d2fb8d9b00f3674721ca155acd089b1da743950434c907e76fee3a9b90"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "strum 0.26.2",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dd06bf366c60f69411668b26d6ab3c55120aa6d423e6af0373ec23d8957300"
+checksum = "587b791efe6c5f18e09dbbaf1ece0ee7b5fe51602c233e7151a3676b0de0260b"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ca60d713f8ddb03bbebcc755d5e6463fdc0b6259fabfc4221b20a5f1e428fd"
+checksum = "c5211d11b84d8c8d2674fed81503ddad385782b50c7f60f5e3551d7f2dc8098f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12846,8 +12938,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 33.0.0",
+ "sp-runtime 38.0.1",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "182812315871732372325f0ad42bb8b85a093a06dd77ae1eec997259f4c32aef"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -12860,7 +12965,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 38.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afffbddc380d99a90c459ba1554bbbc01d62e892de9f1485af6940b89c4c0d57"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
@@ -12883,22 +13002,49 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
- "sp-state-machine",
+ "sp-state-machine 0.42.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 36.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ef7eb561bb4839cc8424ce58c5ea236cbcca83f26fcc0426d8decfe8aa97d4"
+dependencies = [
+ "bytes",
+ "docify",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine 0.43.0",
+ "sp-tracing",
+ "sp-trie 37.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03536e1ff3ec2bd8181eeaa26c0d682ebdcbd01548a055cf591077188b8c3f0"
+checksum = "7c0e20624277f578b27f44ecfbe2ebc2e908488511ee2c900c5281599f700ab3"
 dependencies = [
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "strum 0.26.2",
 ]
 
@@ -12937,57 +13083,57 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f65a570519da820ce3dc35053497a65f9fbd3f5a7dc81fa03078ca263e9311e"
+checksum = "3b0b017dd54823b6e62f9f7171a1df350972e5c6d0bf17e0c2f78680b5c31942"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47412a2d2e988430d5f59d7fec1473f229e1ef5ce24c1ea4f601b4b3679cac52"
+checksum = "328c7c8280f3d540f98cbf8f84df619a692b1d497db28dda66a710d4a8616e71"
 dependencies = [
  "log",
  "parity-scale-codec",
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0c51a7b60cd663f2661e6949069eb316b092f22c239691d5272a4d0cfca0fb"
+checksum = "af922f112c7c1ed199eabe14f12a82ceb75e1adf0804870eccfbcf3399492847"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe721c367760bddf10fcfa24fb48edd64c442f71db971f043c8ac73f51aa6e9"
+checksum = "2d9de237d72ecffd07f90826eef18360208b16d8de939d54e61591fac0fcbf99"
 dependencies = [
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -13014,9 +13160,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "38.0.0"
+version = "38.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ef409c414546b655ec1e94aaea178e4a97e21284a91b24c762aebf836d3b49"
+checksum = "5273900f0b0bef48b2e1ff9c4fb5e188b8168ee5891418a427f4be2af92ee40f"
 dependencies = [
  "docify",
  "either",
@@ -13030,12 +13176,40 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
+ "sp-application-crypto 37.0.0",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
+ "sp-io 37.0.0",
  "sp-std",
  "sp-weights",
+ "tracing",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5641385c2cd8e2252aacf35e0aff2f236331dfaea8dc11c5a4ec6bb36544450"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rand",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io 38.0.0",
+ "sp-std",
+ "sp-weights",
+ "tracing",
 ]
 
 [[package]]
@@ -13074,17 +13248,17 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4daf2e40ffc7e7e8de08efb860eb9534faf614a49c53dc282f430faedb4aed13"
+checksum = "d04fcd2d1270038be94d00103e8e95f7fbab9075dcc78096b91d8931ee970d73"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-core",
  "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 39.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
@@ -13098,7 +13272,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 38.0.1",
+]
+
+[[package]]
+name = "sp-staking"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143a764cacbab58347d8b2fd4c8909031fb0888d7b02a0ec9fa44f81f780d732"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -13116,7 +13304,28 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-trie",
+ "sp-trie 36.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930104d6ae882626e8880d9b1578da9300655d337a3ffb45e130c608b6c89660"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "smallvec",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie 37.0.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -13124,9 +13333,9 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03aa86b1b46549889d32348bc85a8135c725665115567507231a6d85712aaac"
+checksum = "c219bc34ef4d1f9835f3ed881f965643c32034fcc030eb33b759dadbc802c1c2"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -13136,12 +13345,12 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-core",
  "sp-crypto-hashing",
  "sp-externalities",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-runtime-interface",
  "thiserror",
  "x25519-dalek",
@@ -13168,14 +13377,14 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78becf144a76f6fd108dfe94a90e20a185b38c0b310dc5482328196143c8266b"
+checksum = "72a1cb4df653d62ccc0dbce1db45d1c9443ec60247ee9576962d24da4c9c6f07"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
  "thiserror",
 ]
 
@@ -13193,27 +13402,27 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c9d1604aadc15b70e95f4388d0b1aa380215520b7ddfd372531a6d8262269c"
+checksum = "fc4bf251059485a7dd38fe4afeda8792983511cc47f342ff4695e2dcae6b5247"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5a891cb913015bb99401e372255193cc3848c6fe5c2f6fe2383ef9588cb190"
+checksum = "c765c2e9817d95f13d42a9f2295c60723464669765c6e5acbacebd2f54932f67"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -13221,6 +13430,30 @@ name = "sp-trie"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d717c0f465f5371569e6fdc25b6f32d47c15d6e4c92b3b779e1c9b18b951d"
+dependencies = [
+ "ahash",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "scale-info",
+ "schnellru",
+ "sp-core",
+ "sp-externalities",
+ "thiserror",
+ "tracing",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6282aef9f4b6ecd95a67a45bcdb67a71f4a4155c09a53c10add4ffe823db18cd"
 dependencies = [
  "ahash",
  "hash-db",
@@ -13252,7 +13485,25 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 38.0.1",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d521a405707b5be561367cd3d442ff67588993de24062ce3adefcf8437ee9fe1"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 39.0.0",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13352,17 +13603,16 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd00d586b0dac4f42736bdd0ad52213a891b240e011ea82b38938263dd821c25"
+checksum = "8e65e4397580154b0f6760350f51a97afa2ecabcbb3cc133a5116940c1b36a6a"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -13390,21 +13640,43 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847fa2afe1bed2751eaabf7b91fa4043037947f17653d7cc59ea202cc44c6bb8"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 36.0.1",
+ "frame-system 36.1.0",
  "impl-trait-for-tuples",
  "log",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 36.0.0",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 13.0.0",
  "scale-info",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm-executor 15.0.0",
+]
+
+[[package]]
+name = "staging-xcm-builder"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bda935caf05b0d1bd929e0211bbc2d1815fa45977e72880f00b49f42688142"
+dependencies = [
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-transaction-payment 37.0.0",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives 14.0.0",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-executor 16.0.0",
 ]
 
 [[package]]
@@ -13414,19 +13686,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b98d8219449eaf02e71a7edf1a14b14d4c713dd01d9df66fde1ce30dba4d6d"
 dependencies = [
  "environmental",
- "frame-benchmarking",
- "frame-support",
+ "frame-benchmarking 36.0.0",
+ "frame-support 36.0.1",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-io 37.0.0",
+ "sp-runtime 38.0.1",
  "sp-std",
  "sp-weights",
  "staging-xcm",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f6e90f1605540994f0186eaa713f1d636d3afc34cf0887b01b880921c845fc"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.0.0",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+ "sp-weights",
+ "staging-xcm",
+ "tracing",
 ]
 
 [[package]]
@@ -13562,9 +13855,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "36.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b8837de37f5ea6316846a63dc48489b63ebde05df73ba7d7077b3135487560"
+checksum = "bdf4468637471dd481811d0d1ffaf8e8a98165d9ad6b586bfb2911ca1cb081f5"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -13574,11 +13867,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 34.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
 ]
 
 [[package]]
@@ -13596,9 +13889,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246ac77a641b23068e8c49cff4dfbaefc78405f80c9589a10909e02d525141"
+checksum = "5befa8817599e4c2bb499e4361879f5ac7832bb9e264e508f80f86fb5f40ed87"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13606,17 +13899,17 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 39.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
  "trie-db",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
+checksum = "0104598a022d22430f27e535b7aed148af9dcd0a3eb23697c02168071a325e33"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -13630,10 +13923,10 @@ dependencies = [
  "polkavm-linker",
  "sc-executor",
  "sp-core",
- "sp-io",
+ "sp-io 38.0.0",
  "sp-maybe-compressed-blob",
  "sp-tracing",
- "sp-version",
+ "sp-version 37.0.0",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.14",
@@ -14173,9 +14466,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07f52b2b1a1c1c21094bd0b6fdcf1b7dbe785b937b30e82dba688d55d988efb"
+checksum = "ef628f1f640ec158696301646e34ed05f6b9770bd8d11fda03278e4aae2203ba"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -15082,18 +15375,18 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b8918bb9fe4938757d4f003b7fa26598a632e350feac4e7477bb6b36e2f2af"
+checksum = "9e5fba32e087a2b7803ba3dae251f345eb0b577f2394e903cdb4efcfa27480e2"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
- "frame-benchmarking",
+ "frame-benchmarking 37.0.0",
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
+ "frame-support 37.0.0",
+ "frame-system 37.1.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -15104,7 +15397,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-babe",
  "pallet-bags-list",
- "pallet-balances",
+ "pallet-balances 38.0.0",
  "pallet-beefy",
  "pallet-beefy-mmr",
  "pallet-collective",
@@ -15142,7 +15435,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
- "pallet-transaction-payment",
+ "pallet-transaction-payment 37.0.0",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
  "pallet-utility",
@@ -15151,7 +15444,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
+ "polkadot-parachain-primitives 14.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -15159,30 +15452,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.15.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-staking 34.0.0",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 37.0.0",
  "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
+ "staging-xcm-builder 16.0.0",
+ "staging-xcm-executor 16.0.0",
  "substrate-wasm-builder",
  "westend-runtime-constants",
  "xcm-runtime-apis",
@@ -15190,19 +15482,19 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7a91c27c398b11f7633cc2382cbba53b02e7196ebe8fff13c170e54a54e9d8"
+checksum = "8d5b6e2fa3bd463410e65dbe7931f5b4ee19ae8db6d1c87071e38e9e3d17a616"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
- "sp-runtime",
+ "sp-runtime 39.0.0",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-builder",
+ "staging-xcm-builder 16.0.0",
 ]
 
 [[package]]
@@ -15612,18 +15904,17 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fffcd9128a46abd836c37dd001c2cbe122aeb8904cd7b9bac8358564fb7b56"
+checksum = "3fbf11b1fb43e9beb4a3c1c613c3a791ff16ab270566c1ce80f346b09afdced1"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-std",
+ "sp-api 34.0.0",
  "sp-weights",
  "staging-xcm",
- "staging-xcm-executor",
+ "staging-xcm-executor 16.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ pallet-balances = { version = "38.0.0", default-features = false }
 pallet-message-queue = { version = "40.0.0", default-features = false }
 pallet-session = { version = "37.0.0", default-features = false }
 pallet-sudo = { version = "37.0.0", default-features = false }
-pallet-timestamp = { version = "36.0.0", default-features = false }
+pallet-timestamp = { version = "36.0.1", default-features = false }
 pallet-transaction-payment = { version = "37.0.0", default-features = false }
 pallet-transaction-payment-rpc = "40.0.0"
 pallet-transaction-payment-rpc-runtime-api = { version = "37.0.0", default-features = false }
@@ -94,7 +94,7 @@ sp-version = { version = "37.0.0", default-features = false }
 substrate-frame-rpc-system = "38.0.0"
 
 # Contracts
-pallet-contracts = { version = "35.0.0", default-features = false }
+pallet-contracts = { version = "37.0.0", default-features = false }
 
 # Polkadot
 pallet-xcm = { version = "16.0.0", default-features = false }
@@ -109,7 +109,7 @@ xcm-executor = { version = "16.0.0", package = "staging-xcm-executor", default-f
 # Cumulus
 cumulus-client-cli = "0.17.0"
 cumulus-client-collator = "0.17.0"
-cumulus-client-consensus-aura = "0.17.0"
+cumulus-client-consensus-aura = "0.17.1"
 cumulus-client-consensus-common = "0.17.0"
 cumulus-client-consensus-proposer = "0.15.0"
 cumulus-client-service = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,97 +32,98 @@ smallvec = "1.11.2"
 
 # Build
 substrate-build-script-utils = "11.0.0"
-substrate-wasm-builder = "23.0.0"
+substrate-wasm-builder = "24.0.0"
 
 # Local
 parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
-frame-benchmarking = { version = "36.0.0", default-features = false }
-frame-benchmarking-cli = "40.0.0"
-frame-executive = { version = "36.0.0", default-features = false }
-frame-support = { version = "36.0.0", default-features = false }
-frame-system = { version = "36.1.0", default-features = false }
-frame-system-benchmarking = { version = "36.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "33.0.0", default-features = false }
-frame-try-runtime = { version = "0.42.0", default-features = false }
-frame-metadata-hash-extension = { version = "0.4.0", default-features = false }
-pallet-aura = { version = "35.0.0", default-features = false }
-pallet-authorship = { version = "36.0.0", default-features = false }
-pallet-balances = { version = "37.0.0", default-features = false }
-pallet-message-queue = { version = "39.0.0", default-features = false }
-pallet-session = { version = "36.0.0", default-features = false }
-pallet-sudo = { version = "36.0.0", default-features = false }
-pallet-timestamp = { version = "35.0.0", default-features = false }
-pallet-transaction-payment = { version = "36.0.0", default-features = false }
-pallet-transaction-payment-rpc = "38.0.0"
-pallet-transaction-payment-rpc-runtime-api = { version = "36.0.0", default-features = false }
+frame-benchmarking = { version = "37.0.0", default-features = false }
+frame-benchmarking-cli = "42.0.0"
+frame-executive = { version = "37.0.0", default-features = false }
+frame-support = { version = "37.0.0", default-features = false }
+frame-support-procedural = { version = "30.0.2", default-features = false }
+frame-system = { version = "37.1.0", default-features = false }
+frame-system-benchmarking = { version = "37.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "34.0.0", default-features = false }
+frame-try-runtime = { version = "0.43.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.5.0", default-features = false }
+pallet-aura = { version = "36.0.0", default-features = false }
+pallet-authorship = { version = "37.0.0", default-features = false }
+pallet-balances = { version = "38.0.0", default-features = false }
+pallet-message-queue = { version = "40.0.0", default-features = false }
+pallet-session = { version = "37.0.0", default-features = false }
+pallet-sudo = { version = "37.0.0", default-features = false }
+pallet-timestamp = { version = "36.0.0", default-features = false }
+pallet-transaction-payment = { version = "37.0.0", default-features = false }
+pallet-transaction-payment-rpc = "40.0.0"
+pallet-transaction-payment-rpc-runtime-api = { version = "37.0.0", default-features = false }
 prometheus-endpoint = { version = "0.17.0", default-features = false, package = "substrate-prometheus-endpoint" }
-sc-basic-authorship = "0.42.0"
-sc-chain-spec = "35.0.0"
-sc-cli = "0.44.0"
-sc-client-api = "35.1.0"
-sc-offchain = "37.0.0"
-sc-consensus = "0.41.0"
-sc-executor = "0.39.0"
-sc-network = "0.42.0"
-sc-network-sync = "0.41.0"
-sc-rpc = "37.0.0"
-sc-service = "0.43.0"
-sc-sysinfo = "35.0.0"
-sc-telemetry = "22.0.0"
-sc-tracing = "35.0.0"
-sc-transaction-pool = "35.0.0"
-sc-transaction-pool-api = "35.0.0"
-sp-api = { version = "33.0.0", default-features = false }
-sp-block-builder = { version = "33.0.0", default-features = false }
-sp-blockchain = "35.1.0"
-sp-consensus-aura = { version = "0.39.0", default-features = false }
+sc-basic-authorship = "0.44.0"
+sc-chain-spec = "37.0.0"
+sc-cli = "0.46.0"
+sc-client-api = "37.0.0"
+sc-offchain = "39.0.0"
+sc-consensus = "0.43.0"
+sc-executor = "0.40.0"
+sc-network = "0.44.0"
+sc-network-sync = "0.43.0"
+sc-rpc = "39.0.0"
+sc-service = "0.45.0"
+sc-sysinfo = "37.0.0"
+sc-telemetry = "24.0.0"
+sc-tracing = "37.0.0"
+sc-transaction-pool = "37.0.0"
+sc-transaction-pool-api = "37.0.0"
+sp-api = { version = "34.0.0", default-features = false }
+sp-block-builder = { version = "34.0.0", default-features = false }
+sp-blockchain = "37.0.1"
+sp-consensus-aura = { version = "0.40.0", default-features = false }
 sp-core = { version = "34.0.0", default-features = false }
-sp-io = { version = "37.0.0", default-features = false }
-sp-genesis-builder = { version = "0.14.0", default-features = false }
-sp-inherents = { version = "33.0.0", default-features = false }
+sp-io = { version = "38.0.0", default-features = false }
+sp-genesis-builder = { version = "0.15.0", default-features = false }
+sp-inherents = { version = "34.0.0", default-features = false }
 sp-keystore = "0.40.0"
-sp-offchain = { version = "33.0.0", default-features = false }
-sp-runtime = { version = "38.0.0", default-features = false }
-sp-session = { version = "34.0.0", default-features = false }
+sp-offchain = { version = "34.0.0", default-features = false }
+sp-runtime = { version = "39.0.0", default-features = false }
+sp-session = { version = "35.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = "33.0.0"
-sp-transaction-pool = { version = "33.0.0", default-features = false }
-sp-version = { version = "36.0.0", default-features = false }
-substrate-frame-rpc-system = "36.0.0"
+sp-timestamp = "34.0.0"
+sp-transaction-pool = { version = "34.0.0", default-features = false }
+sp-version = { version = "37.0.0", default-features = false }
+substrate-frame-rpc-system = "38.0.0"
 
 # Contracts
 pallet-contracts = { version = "35.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "15.0.0", default-features = false }
-polkadot-cli = "15.0.0"
-polkadot-parachain-primitives = { version = "13.0.0", default-features = false }
-polkadot-primitives = "14.0.0"
-polkadot-runtime-common = { version = "15.0.0", default-features = false }
-xcm = { version = "14.0.3", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "15.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "15.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "16.0.0", default-features = false }
+polkadot-cli = "17.0.0"
+polkadot-parachain-primitives = { version = "14.0.0", default-features = false }
+polkadot-primitives = "15.0.0"
+polkadot-runtime-common = { version = "16.0.0", default-features = false }
+xcm = { version = "14.1.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "16.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "16.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.15.0"
-cumulus-client-collator = "0.15.0"
-cumulus-client-consensus-aura = "0.15.0"
-cumulus-client-consensus-common = "0.15.0"
-cumulus-client-consensus-proposer = "0.14.0"
-cumulus-client-service = "0.15.0"
-cumulus-pallet-aura-ext = { version = "0.15.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.15.0", default-features = false }
-cumulus-pallet-session-benchmarking = { version = "17.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.15.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.15.0", default-features = false }
-cumulus-primitives-aura = { version = "0.14.0", default-features = false }
-cumulus-primitives-core = { version = "0.14.0", default-features = false }
-cumulus-primitives-parachain-inherent = "0.14.0"
-cumulus-primitives-storage-weight-reclaim = { version = "6.0.2", default-features = false }
-cumulus-primitives-utility = { version = "0.15.0", default-features = false }
-cumulus-relay-chain-interface = "0.15.0"
-pallet-collator-selection = { version = "17.0.0", default-features = false }
-parachains-common = { version = "15.0.0", default-features = false }
-parachain-info = { version = "0.15.0", package = "staging-parachain-info", default-features = false }
+cumulus-client-cli = "0.17.0"
+cumulus-client-collator = "0.17.0"
+cumulus-client-consensus-aura = "0.17.0"
+cumulus-client-consensus-common = "0.17.0"
+cumulus-client-consensus-proposer = "0.15.0"
+cumulus-client-service = "0.17.0"
+cumulus-pallet-aura-ext = { version = "0.16.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.16.0", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "18.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.16.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.16.0", default-features = false }
+cumulus-primitives-aura = { version = "0.15.0", default-features = false }
+cumulus-primitives-core = { version = "0.15.0", default-features = false }
+cumulus-primitives-parachain-inherent = "0.15.0"
+cumulus-primitives-storage-weight-reclaim = { version = "7.0.1", default-features = false }
+cumulus-primitives-utility = { version = "0.16.0", default-features = false }
+cumulus-relay-chain-interface = "0.17.0"
+pallet-collator-selection = { version = "18.0.0", default-features = false }
+parachains-common = { version = "17.0.0", default-features = false }
+parachain-info = { version = "0.16.0", package = "staging-parachain-info", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -77,7 +77,8 @@ cumulus-primitives-parachain-inherent.workspace = true
 cumulus-relay-chain-interface.workspace = true
 
 [features]
-default = []
+default = ["std"]
+std = ["log/std", "xcm/std"]
 runtime-benchmarks = [
     "cumulus-primitives-core/runtime-benchmarks",
     "frame-benchmarking-cli/runtime-benchmarks",

--- a/node/README.md
+++ b/node/README.md
@@ -5,7 +5,7 @@
 🔗 It communicates with other nodes in the network, and aims for
 [consensus](https://wiki.polkadot.network/docs/learn-consensus) among them.
 
-⚙️ It can act as a remote procedure call (RPC) server, allowing interaction with the blockchain.
+⚙️ It acts as a remote procedure call (RPC) server, allowing interaction with the blockchain.
 
 👉 Learn more about the architecture, and the difference between a node and a runtime
 [here](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/wasm_meta_protocol/index.html).

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -33,7 +33,6 @@ use sc_client_api::Backend;
 use sc_consensus::ImportQueue;
 use sc_executor::{HeapAllocStrategy, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY};
 use sc_network::NetworkBlock;
-use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
@@ -178,7 +177,6 @@ fn start_consensus(
     task_manager: &TaskManager,
     relay_chain_interface: Arc<dyn RelayChainInterface>,
     transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
-    sync_oracle: Arc<SyncingService<Block>>,
     keystore: KeystorePtr,
     relay_chain_slot_duration: Duration,
     para_id: ParaId,
@@ -215,7 +213,6 @@ fn start_consensus(
                 .ok()
                 .map(|c| ValidationCode::from(c).hash())
         },
-        sync_oracle,
         keystore,
         collator_key,
         para_id,
@@ -227,10 +224,9 @@ fn start_consensus(
         reinitialize: false,
     };
 
-    let fut =
-        aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(
-            params,
-        );
+    let fut = aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _>(
+        params,
+    );
     task_manager
         .spawn_essential_handle()
         .spawn("aura", None, fut);
@@ -409,7 +405,6 @@ pub async fn start_parachain_node(
             &task_manager,
             relay_chain_interface,
             transaction_pool,
-            sync_service,
             params.keystore_container.keystore(),
             relay_chain_slot_duration,
             para_id,

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -4,7 +4,7 @@
 responsible for validating blocks and executing the state changes they define.
 
 💁 The runtime in this template is constructed using ready-made FRAME pallets that ship with
-[Polkadot SDK](https://github.com/paritytech/polkadot-sdk).
+[Polkadot SDK](https://github.com/paritytech/polkadot-sdk), and a [template for a custom pallet](../pallets/README.md).
 
 👉 Learn more about FRAME
 [here](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/frame_runtime/index.html).

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -4,7 +4,7 @@
 responsible for validating blocks and executing the state changes they define.
 
 💁 The runtime in this template is constructed using ready-made FRAME pallets that ship with
-[Polkadot SDK](https://github.com/paritytech/polkadot-sdk), and a [template for a custom pallet](../pallets/README.md).
+[Polkadot SDK](https://github.com/paritytech/polkadot-sdk).
 
 👉 Learn more about FRAME
 [here](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/frame_runtime/index.html).

--- a/runtime/src/configs/contracts.rs
+++ b/runtime/src/configs/contracts.rs
@@ -108,6 +108,7 @@ impl pallet_contracts::Config for Runtime {
     type MaxCodeLen = ConstU32<{ 256 * 1024 }>;
     type DefaultDepositLimit = DefaultDepositLimit;
     type MaxStorageKeyLen = ConstU32<128>;
+    type MaxTransientStorageSize = ConstU32<{ 1024 * 1024 }>;
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
     type UnsafeUnstableInterface = ConstBool<true>;
     type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;


### PR DESCRIPTION
Status: ✅ Compiled and built successfully

- Reference: https://github.com/r0gue-io/base-parachain/pull/45
- Release: https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2407-1, https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2407

- Compare [Parachain Template (v1.14.0)](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.14.0/templates/parachain) vs [Parachain Template (stable2407)](https://github.com/paritytech/polkadot-sdk/tree/stable2407/templates/parachain)
- Compare [pallet-contracts (v1.14.0)](https://github.com/paritytech/polkadot-sdk/commits/polkadot-v1.14.0/substrate/frame/contracts) vs [pallet-contracts (stable2407)](https://github.com/paritytech/polkadot-sdk/commits/polkadot-stable2407/substrate/frame/contracts)

## Direct changes
- [[#5011](https://github.com/paritytech/polkadot-sdk/pull/5011)]: Use `BadOrigin` from `sp_runtime`
- [[#4097](https://github.com/paritytech/polkadot-sdk/pull/4097)]: Introduce experimental slot-based collator
- [[#5040](https://github.com/paritytech/polkadot-sdk/pull/5040)]: Update libp2p-websocket to v0.42.2
- [pallet_contracts] Add support for transient storage in contracts host functions: https://github.com/paritytech/polkadot-sdk/commit/eac2a22a4801e1539a97a7fd5bf5fd3916a4339b