### PR TITLE
chore: upgrade to stable2412-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -373,17 +373,17 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "607495ec7113b178fbba7a6166a27f99e774359ef4823adbefd756b5b81d7970"
 dependencies = [
- "asn1-rs-derive 0.5.1",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl 0.2.0",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -808,7 +808,7 @@ dependencies = [
  "bs58",
  "hmac 0.12.1",
  "k256",
- "rand_core",
+ "rand_core 0.6.4",
  "ripemd",
  "secp256k1 0.27.0",
  "sha2 0.10.8",
@@ -1703,7 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1715,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c82955fc41802846be0bfd46395a942105f2e50e002c8eac641c5e9fa299a5"
+checksum = "df26583f9ecfd126772a0ce073e32372b01605a528067f79b125581c69072c80"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a2d4f03d7f20128f581cfce23c657101df652708baf9f27cb43fec952c1367"
+checksum = "cef5a127360a0588e1c460da468beb0fed75985da439b7cbe487fa120b9e5fa4"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27627e0ba196a1d45296c317cc83cbf974863cb3792923aafbe756d1ec9c47a"
+checksum = "797249e27522966baae0f95c274ad27383edee4c143811bf1dad228e7688a5c0"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1839,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66eb6a615253ef33bdd07ff6c0f72f82e39fbee7987a5b1ee17c98e1dc87b666"
+checksum = "a88d8e868d1ea999443ca7b1b402756ea633f88885786a6d3060525606a98698"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a071b6e1ceb76e5da46c771d96faf608985662f4b57bfb17eeedb6a402001eb"
+checksum = "42ae352bfa45581086fde4035cab5720a8dee8421924b213d8778f26d7e2da7f"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a676fcdd10c65e084e3488b37862bf7efd1fa40a41c2288d25b11b30681075"
+checksum = "01a2576bb0ac3aaea5b3c0fb936c571f283489da9b78de5fc0912b4c65f6b6ea"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9327ce06630f74c77bc5e14bd26ee1b0257360afe5a605be08ad17fce23e05"
+checksum = "878ea642d9d7febd19b8121aec1e9bc507de1d2a8ace1c7ddee5208d5491e488"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1950,7 +1950,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
  "sp-api",
@@ -1963,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcad4340f9d50e1694cc38cef446f89e29815fd113ec2769d36f44507f02eb65"
+checksum = "90c904835fd1262ec058628bc568a4a3fa56a70cdeef5117dba1c9d773dea622"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1f3d0e7e430ddcd86b0a9cda56a4bbe3222774ba5c9a29b427dc773c0aa1fc"
+checksum = "9dcd28e856c7667eac03df9ef162aaaba6521b9500f209979581d27c9ac36a07"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2213,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cc8d24717b001a6de5a4cf3dbdb1d3ede97d6696d7858dc554ab435658444a"
+checksum = "86c87bc0cec115dbe277089dfa7ded93b228a72b5e51fbfc0307dd17bdbb5b6d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23775ed386f689a927e9771b33496acce6f9bbff8cac7035cfcb8e73df9eb8f"
+checksum = "1d2bc7a96dde69a73798ce2fcab96a99cea4e9decc6adabf1110bedef2454e0e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922520bb2e43573db377b4476f10bbd894648078e12dc6207e8786c1d3791b24"
+checksum = "0ed3966ae0f659e2a18bbc231fb7820f77e5a63eb36aea688e86338154452c10"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08ca1537400fa6aa3fd033f07215cfa733a9809c104aaa7a70c70ab6fb007ba"
+checksum = "0ee9f20c8afea27fe6f464a415c2bd9685c7487a82950c56abd1cffa8f61b238"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2309,7 +2309,7 @@ dependencies = [
  "pin-project",
  "polkadot-overseer",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -2383,7 +2383,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
@@ -2582,11 +2582,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs 0.7.0",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2863,7 +2863,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -2880,7 +2880,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "zeroize",
 ]
@@ -2904,7 +2904,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -3177,7 +3177,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3252,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3351,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "45.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae0022b987e68dae7e6668c24d54f3251b64352ca8f18b4a22c7bb2a2a20ecd"
+checksum = "2d3be80e9ea90ec635ce6f40a16342ec5ac6ebb18a3a8a97bcb4fa444755d648"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3374,7 +3374,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
  "sc-chain-spec",
@@ -3911,8 +3911,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4019,7 +4019,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -4031,7 +4031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -4206,7 +4206,7 @@ dependencies = [
  "idna 1.0.3",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -4227,7 +4227,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -4693,7 +4693,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -5152,7 +5152,7 @@ dependencies = [
  "jsonrpsee-types 0.24.8",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5521,7 +5521,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
  "thiserror 1.0.69",
@@ -5579,7 +5579,7 @@ dependencies = [
  "hkdf",
  "multihash 0.19.3",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
@@ -5606,7 +5606,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
  "thiserror 1.0.69",
@@ -5628,7 +5628,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.5.8",
  "tokio",
@@ -5669,7 +5669,7 @@ dependencies = [
  "multihash 0.19.3",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -5692,7 +5692,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "void",
 ]
 
@@ -5712,7 +5712,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "quinn",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustls 0.21.12",
  "socket2 0.5.8",
@@ -5733,7 +5733,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "void",
 ]
@@ -5755,7 +5755,7 @@ dependencies = [
  "log",
  "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "void",
@@ -5871,7 +5871,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "thiserror 1.0.69",
- "yamux",
+ "yamux 0.12.1",
 ]
 
 [[package]]
@@ -5913,7 +5913,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -6030,9 +6030,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litep2p"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0fef34af8847e816003bf7fdeac5ea50b9a7a88441ac927a6166b5e812ab79"
+checksum = "3e5a3d13ee6af6f01bb2093aa6d5f29b79ede7de6277e5d0394e8f5d8eaa5a86"
 dependencies = [
  "async-trait",
  "bs58",
@@ -6049,12 +6049,11 @@ dependencies = [
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
- "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "rcgen",
  "ring 0.16.20",
  "rustls 0.20.9",
@@ -6064,18 +6063,18 @@ dependencies = [
  "smallvec",
  "snow",
  "socket2 0.5.8",
- "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uint 0.9.5",
+ "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
- "x509-parser 0.16.0",
+ "x509-parser 0.17.0",
+ "yamux 0.13.4",
  "yasna",
  "zeroize",
 ]
@@ -6300,7 +6299,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -6347,8 +6346,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.6.1",
  "thiserror 1.0.69",
@@ -6357,9 +6356,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694dbecb27aba7d0ef6ee333cf327ae6b9260982d0b4c2f53531d847faddbd11"
+checksum = "636f8e95fc10aa66439cb73ef97656da0c74b68b346d6d0f7ca83c3cc44a23cd"
 dependencies = [
  "futures",
  "log",
@@ -6598,7 +6597,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6895,11 +6894,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs 0.7.0",
 ]
 
 [[package]]
@@ -7135,9 +7134,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5800e106650e41577d852e003a212b82998bb2fd1e348ed08436ef620fd094f"
+checksum = "8b3d18caaae72674d6536d339c1ae5b5063b55de5813a43ee045847d28c0a128"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7265,7 +7264,7 @@ dependencies = [
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-runtime",
  "sp-staking",
@@ -7307,7 +7306,7 @@ dependencies = [
  "pallet-contracts-uapi",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "scale-info",
  "serde",
@@ -7410,7 +7409,7 @@ dependencies = [
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -7844,9 +7843,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10ac8ebf3b548b2fcb0d6b848eed0b0824bb857db99e12275338d674e565d06"
+checksum = "9af226b2b988725708ae7771fa53a2a1cfbc57a0e7f02f65d570d26cb4c95791"
 dependencies = [
  "bitflags 1.3.2",
  "derive_more 0.99.19",
@@ -7972,7 +7971,7 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "sp-runtime",
  "sp-session",
 ]
@@ -7988,7 +7987,7 @@ dependencies = [
  "frame-system",
  "log",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
@@ -8009,7 +8008,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -8041,9 +8040,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc22f82e0f13e0e7c34a51a8e4750d0b0a3fe063be68e8bc94d5def61a18afc"
+checksum = "f5085315d359bc340581b1a5133edd060e9357f475ac74215e4dca53f571bc6c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8429,8 +8428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -8450,7 +8449,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -8558,7 +8557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -8725,9 +8724,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf37bcefe517f3d7b2540ede5ccd6abac8ac65609a1f5581b0b4d4bf6c38f0c2"
+checksum = "5c4fa9edaa90d9ebe3670ab8907e8f3d93bd83a6a56938bb8189b6abe95e640f"
 dependencies = [
  "bitvec",
  "futures",
@@ -8739,15 +8738,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22ebb3e7eeb5db8db0637c9c6e782f6fd74a8ee100aa3d470831068c3da2481"
+checksum = "fdf2919ac8452f679f40503affa9556770e34849e95ad0541c430d91fcaf11e1"
 dependencies = [
  "always-assert",
  "futures",
@@ -8756,15 +8755,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce6d05c74e4947f38eebf41034610d8f766e61f3f9c98122c1359aa3b560eb3"
+checksum = "8320bdf8006985e2a0ef0d598246342457360aee8f9aa1e80d59727ab185f4c6"
 dependencies = [
  "derive_more 0.99.19",
  "fatality",
@@ -8776,7 +8775,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "sp-core",
@@ -8787,9 +8786,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403b4aaa863b87b41c14ef3ebc0073d3fdef9cf71089eb3cab460bd4e1a30783"
+checksum = "05ee9e768b721d4995e57048db953a182d8fcc197120efdefc52408af6e61c22"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8801,7 +8800,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "schnellru",
  "thiserror 1.0.69",
@@ -8821,9 +8820,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "21.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39455b847e52f4da0b221b8a1c466adcea1b1a94c257a6335cd11188d974e66c"
+checksum = "757fb851ce032e6988fd920b797b1d0e26af7dcda4c92a52e50bca18e24edc36"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8850,9 +8849,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32450c6f16c25083e291cb6e7e684f26e34403ce0a7d34b625613d86155bc168"
+checksum = "a7b4ad0b6fe08025f7c1a6fd2b2d191f739565590d46c18d6a84903c8807448b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8886,9 +8885,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "20.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db600906a1579f601bffefe15679865294e6d50b3d20b500fc27ac572cab91f"
+checksum = "144a3f4b8481d9958d3bc12155c663c7460b1d312f69948b4056ca2b01688f82"
 dependencies = [
  "derive_more 0.99.19",
  "fatality",
@@ -8927,9 +8926,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3ea65272716280ebd772bdd671737f6a71c068d654c476fa777bcec203d3ba"
+checksum = "ce005a50bfab11636e85c35fa4fc178fdcb741c07a995e875970582a53db24c8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8937,8 +8936,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
  "sp-application-crypto",
@@ -8950,9 +8949,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a331852ef32d8b6560f4ef736701c4eef9c2065b3a37c52bd254d05c2596f5"
+checksum = "1aa796064c842e346fd74a6ed06f156a5a89219a5e7a7aebcc19871086e03aa0"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8974,9 +8973,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea889178da28dab50e1439029d4e511ad19d8d2359334092332d8bc8ba01117"
+checksum = "f6fdc6167fe8700680d962a320018e0952425339f0cd0bbe3b3a770e8b880e44"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8994,9 +8993,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "20.1.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869a7534247e26c7ff65dde467831f69d3645a26c24091553c4bece54d291769"
+checksum = "46f00f245248fb976818676201c7b188ce0712441adc4beb2fa62875d1602933"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -9012,9 +9011,9 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
@@ -9028,9 +9027,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e832343e943197af60488f14502ea4d499bab6353e11c9a117b75b466477a920"
+checksum = "608e6bd879037fefef7fab90e77073b576dff42de8d58b3a11991ecc6d2b38a6"
 dependencies = [
  "async-trait",
  "futures",
@@ -9045,9 +9044,9 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sc-keystore",
  "sp-application-crypto",
  "sp-consensus",
@@ -9059,9 +9058,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df55a9148d98adc50620df92b4bbc909b3b667d70940c8e02dbe3cab1668967a"
+checksum = "ce6cde96b530414138cf0367e7b2e48c67c8f0d8aad165008f68c68828c573c6"
 dependencies = [
  "bitvec",
  "futures",
@@ -9081,9 +9080,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42472db2ef67ed1a7e19be63e5664b7c2bdc15e01bcb3e52db9bb14a1849a95"
+checksum = "c9b4dc8c1987a53677d93321e4976880ee212aee5fd59830b35e68e6d534b151"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9103,9 +9102,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2bf733febfd08a52e665bf48e3caa1d8c8a6e8fa7ce30d569cf4673c23773d"
+checksum = "6828b39e95a437561804daf5a5156c40b3b4dabb581dba499794d87032c348a5"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -9119,9 +9118,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfd922550537cf032081320dbcd9d941742a9074f324cef4c5f2ee4d1f38442"
+checksum = "6dbfdd8c5daf393ae38e564d75af024dc478e98a118bb7a087dcc56afea1530f"
 dependencies = [
  "async-trait",
  "futures",
@@ -9142,9 +9141,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30f36e966352e995d4d665c34d405666c9fc4fdfcbe79d1a0e7d43289c627ac"
+checksum = "a9e808d0b7e9bf119a36f2752cd370d34155909891dbb8e2e315f71c7c7b9b8a"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -9157,9 +9156,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50edbed1b6422f02e18e28e42671aa1d01f2685741e553fbfa36d8e894703719"
+checksum = "5bcbea2a9ed0a4eb60c3c0ef7ec12462e86dc5c3e950cd668cf8a35cc9ab7ee7"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9175,9 +9174,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9685402062442d8548808f3fd5ecb5a6e183daa86ca98795df630511c9aca7f5"
+checksum = "16231169e22447ad68be29b27818a2f243b8ac7d2e7a6bd99f4a3d3aff2869fc"
 dependencies = [
  "fatality",
  "futures",
@@ -9195,9 +9194,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763b90337df42d1d60151c11b56d2204f9051bf451e4d70960aa13e3229a11e"
+checksum = "2828f1a77a35676e2ecba5954f471412c6534e4e1dc6045286ce6731ace93e0d"
 dependencies = [
  "async-trait",
  "futures",
@@ -9213,9 +9212,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57dc40b32809b22047cfea8409f0462fd5b19414d63865578551d023bcecfb9b"
+checksum = "c502b0bcfc047396fd5260d4385a565beb3edfb38713773f189118e967e02f38"
 dependencies = [
  "fatality",
  "futures",
@@ -9228,9 +9227,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27643bef90f447e7e7f92645f90a14aa6bf45307b384bd4c46cebd43065d992"
+checksum = "0ef776bc965bc9a6d19d9daf9b0ce801708284a1b7d9c17221b34658cc3679fd"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9247,9 +9246,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197357e5c3359edae618f79d2bd36bb3f16904c5c7716ae4f90fcf50001cb8b8"
+checksum = "d4781184e0ba4ccc40eb909ca758f7133a19ddf4c91fd9f4212629e579a5b00f"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -9266,7 +9265,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "slotmap",
  "sp-core",
  "strum 0.26.3",
@@ -9278,9 +9277,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f3047082caf416538c6d072645a792e5dec21aa473629fad05a5b80a562812"
+checksum = "db3dce1969592b78f718f9861adbbe2bd496eeef6ed8cdef1bb251271ac073c1"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -9322,9 +9321,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25d4c949bc5c32281cfdc940d5c8c088606358713bb7534a7ddc450940b51e0"
+checksum = "937f6b861675d678c13590813e12dad73f4994a088e4e38ea3b1f8e629b141fe"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -9338,9 +9337,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d40c83897178043fa56d871a651ca653dc2d7472caaeffe979a14d58dae88b"
+checksum = "18d8df33fb512c121780eff3f69ddbdf423b7dc10648949d00089d34342fb7f8"
 dependencies = [
  "bs58",
  "futures",
@@ -9358,9 +9357,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e829bc9d11cfc9b88b5a7d9ae742251d14c425eeddd7dade112129fe21f7073"
+checksum = "4e8b0adb75ec8a26a8c037511c8e40ef2fff71ad3ef0d3dcd185bff44b62596c"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9372,7 +9371,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
@@ -9411,9 +9410,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7adad412e96d5d7a263806d05955476383cab0413586b1aa4ecb752bb3f390f"
+checksum = "6d6b2bc3ff1cbf625a2161925f93490ee3841622378691917c6ca6148810278e"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -9421,9 +9420,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4b0b3633f51c0525f6a01f6c00beb8faf284a1e44270b8e97cd5e25a433cda"
+checksum = "7193b889dc5b82a4aa0022eb26ef3528ac7a0d08dd3749b037b8ab79c1b2f3a0"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -9451,9 +9450,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170ec976b68f523efd606c9bef0b516283c86d1e819e64606a8a9c864555997"
+checksum = "0494218b4baee55d04bc6a97cf5290ca25e337d7bbf4af59e1b5d73e0888c1d9"
 dependencies = [
  "async-trait",
  "derive_more 0.99.19",
@@ -9475,7 +9474,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "schnellru",
  "sp-application-crypto",
@@ -9487,9 +9486,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948e6ba4de5b7f3484750bf2a053918fa969dbb365e4ba9f2d24009ac7a8a768"
+checksum = "269c6bc438e12bcf45944cec2d638922893a9fa3bf21ab6a11c3a2da0f4244eb"
 dependencies = [
  "async-trait",
  "futures",
@@ -9556,9 +9555,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548b25d61acd101c0779a5ca0316bb6d1eafe5cc5884b42d67c1ecd6e0456a73"
+checksum = "b3dc4bf5604fad9c5b89c221a9b5361b47812923f00076d87f2d5e92ce8bbc4c"
 dependencies = [
  "jsonrpsee 0.24.8",
  "mmr-rpc",
@@ -9685,8 +9684,8 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
  "sp-api",
@@ -9742,9 +9741,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "21.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704edc65eaeb0735d570c519616ae851f07f38a1c7944de13bd76f90fc10f305"
+checksum = "a5ff691863b00a368a99cd95eb82493231ad3c36a6c1d00d3b3f81d20d1fadfd"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9853,9 +9852,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "20.0.0"
+version = "21.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcf8dad9faca23775666d3ce0df01415a38cf2e0e0d49f6c2d64d66408fadfd"
+checksum = "268f27f617b994997bf6ced4550a86eb10ecdb80408576579d60cfe459aa9cf3"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -10117,7 +10116,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -10334,8 +10333,8 @@ dependencies = [
  "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "unarray",
@@ -10493,7 +10492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash 1.1.0",
  "rustls 0.21.12",
@@ -10538,8 +10537,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -10549,7 +10559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -10562,13 +10582,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.21",
+]
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10577,7 +10607,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10586,7 +10616,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10862,9 +10892,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "20.0.1"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423be21a26eaf28271dfab1e11a2c284fadd0f5d9afbb0f7bdbf8a6dc9d9dd04"
+checksum = "b2b1db858309261d67c560509d03949ecc4d6627a8062780a90be40e44febcfd"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -11346,9 +11376,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad6894d65154843e649b6006ac257af6f5b6fb0591733e8caba7c91cc29655d"
+checksum = "50b08c2566b805670c989aed71fd72810bbdaab7a12b85a22a1a5c2eec171130"
 dependencies = [
  "async-trait",
  "futures",
@@ -11361,7 +11391,7 @@ dependencies = [
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -11377,9 +11407,9 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af76d24c90ba5e1ada7dd6ddb5a0377a6daa60bb58855a94d9f0d4e990c5037"
+checksum = "e135c7efa86a538c5edb6456e00ffa13816d3a1d53fdba8fa81d6e1d06c9c995"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11416,9 +11446,9 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec902d5d12d2212c0a0d3c78d20d603c93b283a96aeb88a0aa122c9c7a82b06e"
+checksum = "f193a962c3bea44d03d6ec61ef3b54cc3d629a8058a25bcb181d06f1ac7b3a79"
 dependencies = [
  "array-bytes",
  "docify",
@@ -11456,9 +11486,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e78b303d473bf449c3be0dd66f2d96d4d699629e51b82467540e52dc6788a"
+checksum = "60f818d5de5e2069bad34e3d3fb63e531728db7d7667ed02f82456e7f0e2c327"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -11471,7 +11501,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -11554,9 +11584,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72818fc96620f988e58363e2217159573387693be67d39a9c1895413fdb62cc9"
+checksum = "82287d29c4f569b7d6b0589ddb60a0cd5e41c82242b582f347d89a8f28bc305f"
 dependencies = [
  "async-trait",
  "futures",
@@ -11579,9 +11609,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f71f2b8a285f8c0df08b637e80d9d601050acb1b4d98fb11ab96c8aca10ace3"
+checksum = "2cae6c8dfa585db7cdb5057d72c27c67654a9b077c1cf38eeba6fc56ed0d885f"
 dependencies = [
  "async-trait",
  "futures",
@@ -11609,9 +11639,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f759b9b20a19bd562a6c799f603e3ce13437d3f255e2fcde945334c28a2b01cf"
+checksum = "d6342aba8e37a25f20e0d57af9fdc05ac93369ee23a16ba486eb0c40a09a4047"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11646,9 +11676,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91821274f7db77cbceab0d8cc64e1b39e0306887c338e89594548455f09a7f9"
+checksum = "71f014ebcb7b161ef53d55e4d50faabe0a9db846fdea7bbfe0a25616a113fe6a"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -11669,9 +11699,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20a25b652260b02ae7e77ff10683bfc0d9d09a09b24d6ae4be7571cf4331f05"
+checksum = "d2d07a31518858f7d29ef58860d62e19c3b842afa23fbbde4e9475a594f32791"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11706,9 +11736,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141564cf9e72260eac766b0bce63198e882b3a41b1a295e64ee24e86657a0f66"
+checksum = "6836b01c69e0f98ad8f156f6a0a5233622cc26f2906db77f71153f636213d7a4"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -11727,9 +11757,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b54be661e1f04a1b7424e1400b5e8d59be05ea8418186b662a12a16ca8571ca"
+checksum = "db49ba7a929e282406a03ed47b00011ef26525cab9bb0e2ce51026d93c411f8b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11741,9 +11771,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45bdf866a654948962b446ef60e8e20bec653d6def146ce5576bd7a5fe92745"
+checksum = "621e14ebfe294c5e822a69eb12a8d960fa82528830ef09688a9caf1cf8b39d3f"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -11756,7 +11786,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -11786,9 +11816,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302025a882ece5d5b500a85d42f49f012d4b126f8a6956e957a7a2c2baae9522"
+checksum = "7f785e276a4b888894a5709361b785db24baefc0df3a59d337ede7658d295686"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -11807,9 +11837,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d6ff7b02f971f683bf1680c6fbe653632d822cd3ec928d98ec84a469169107"
+checksum = "b3973057fb689d2fc626867858e6589d251c162c7f2d513189e39b104d2bb5c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -11900,9 +11930,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977152c22fbf15a64b7697158a8906f445a98f9d6fe792f7710f5b29e062670a"
+checksum = "ed07e72b3d6db0bee2c18b7737a07a6fbd21cc103e4067165cf71da40ae0f0e1"
 dependencies = [
  "console",
  "futures",
@@ -11933,9 +11963,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e4b0777910b2f6afad5602f71fc56c8ae6907ad9d191da387d37a783899f8f"
+checksum = "9465af602a26f73d129f70a6b979c44f4c6bd28c2fdfc018315df2125d179d60"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -11963,9 +11993,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.47.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f99310c173aa832863e1d11bc4862c270f5bba7048b182ead3d0ba48e71d2d"
+checksum = "3751a666e9e16c73bda5d2531b80e086392a66b6006214e2951e29747f2c5b06"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -11990,7 +12020,7 @@ dependencies = [
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sc-network-types",
@@ -12015,9 +12045,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d40e34e07befbe1ad97c5d48a7bf47a3a8e24285ecbcc6c2c8efefe1440a1c"
+checksum = "425b88da9cc89a85ddb6d693d93aee2a708ad9c230b73f8aa638dbad0c63b535"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -12034,9 +12064,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae19449144b14568cad84b1269292727738728d94277ed909f8a4f6ab22355c"
+checksum = "42289d36ebdd9de6c40b48f555bce7546f5d926211335f8d6ad27aa819c43aca"
 dependencies = [
  "ahash",
  "futures",
@@ -12054,9 +12084,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bcd4abeb5aa215f02d513c384f29bdf755333cfc4d3b2bd031f543ba78d3b2"
+checksum = "da04be64a20ced7775f97014031dae5b5408f460e5abe4f3e733d559cb8a846a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12076,9 +12106,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05af2c9e3f81afca3353c0dcf401fd295526d324d1dc0666f96c88afb5cdeea1"
+checksum = "59ce6a2562c9d4710bc56e0c2841653fd7596ef9708530b7e45e1444222b979b"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12113,9 +12143,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbacbb72e7fea2b35880b828ca3b70c4b4babd09314c15ed71a707bd468c1747"
+checksum = "68a069de44381e1329d7033877d212a8287d779a2f3ebd3748c4fec6ee465e55"
 dependencies = [
  "array-bytes",
  "futures",
@@ -12133,9 +12163,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e7cd57858222942e2ac9284ca4dd298993a06bbcc7e9aa4a31df3b61a7daad"
+checksum = "3001bb4db4dbad087e72c851d983c7b9618e37dce382d86355130f7ec7b79f20"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -12144,16 +12174,16 @@ dependencies = [
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81300efc072e86b2c1c12d1e129803169a278cb60adda7534ed9a555f4dcf08b"
+checksum = "cc5e0b1ad78caf4b34d4acbb3dbe4d13fbbdaafcf8cbed26766e028ac7393275"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -12169,7 +12199,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "rustls 0.23.23",
  "sc-client-api",
  "sc-network",
@@ -12199,9 +12229,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414d16047dbe665ee99e0f9ed28a7a93c198eedbe42a1edf4de0de38cf61ad10"
+checksum = "58ac6a01eb88a5ea7e2ed7e6348f332548262fd00247c263f5b081dff3d1432b"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.8",
@@ -12232,9 +12262,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c852b8bea0ec3886127d8e2fa37a6879865a4cd77cb9edc2bff8e5eb1b16b95"
+checksum = "a5a45ebf7365e369bea319018dd2706929d4d8d8807829a1989dfaf3f1c7125d"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -12253,9 +12283,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee042ec14a511b45539a5d41389ad8f5e58045f7d4bc9582725396df94a4943b"
+checksum = "460bd636ce21bf431d7fffcf7a988c0f35369ecbd1aff00c8edbce42b13dc9e1"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -12278,9 +12308,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f29fb5c0c03941ec176c02b7e7c925f3a2dbd2eefc407162840c7415f1fc1"
+checksum = "3c4734b9d0f16e9d7dc45a75b7f413d58ab612b70b7c63a598eedff58255f88a"
 dependencies = [
  "array-bytes",
  "futures",
@@ -12291,7 +12321,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
@@ -12311,9 +12341,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d390ec80586d27fc1216c27ee985eae4ceca435eb0e796cf8dffc98830e6e"
+checksum = "894407165874a8c81aa51ab5ff5823ca2a2eb7806f5f1b2ab1c2df9bb92cce62"
 dependencies = [
  "async-trait",
  "directories",
@@ -12325,7 +12355,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -12402,9 +12432,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e423159e0dd4d9827facf25bec030c2c4bc52534f90cc07436c0910b1f222e1"
+checksum = "34e3a8c8f7afef805cbc60197997fddc8e67d9f68a7ae8d130224061d18e3d8a"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -12422,15 +12452,15 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85b77f3a581d7cb17caba250d847c3dfc6f1394ddfe9d8d30cdb3036eb8588b"
+checksum = "0e636383d99aa72ab948ea0939df12273a5b0cfe977e71c09ab6cc0379c051c2"
 dependencies = [
  "derive_more 0.99.19",
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -12444,9 +12474,9 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e3fb1ce6e9ec0fc12a2cc417e0b6ae36b4b5dfe39800c89f9388e2fc09f3f2"
+checksum = "c48f501f4b696b6497f0dd181892938bfc6ccf580636ae57b4ab2c05ea15d80f"
 dependencies = [
  "chrono",
  "futures",
@@ -12454,7 +12484,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-network",
  "sc-utils",
  "serde",
@@ -12506,9 +12536,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "38.0.0"
+version = "38.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa9c7be283a1f83531ccade4d44ce16a0c2615276240b05a3c3aa0ff72f4a42"
+checksum = "850d5f7e46e7b6943c2bcc627a82cf11d7604b95a24e2c0e0f28a24fbff4095c"
 dependencies = [
  "async-trait",
  "futures",
@@ -12538,9 +12568,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "38.0.0"
+version = "38.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e152a4db5b2edbfa31cf1473db512008aa8dad4f85bf1bcb180b01a9e0d0be1"
+checksum = "894984d3ba3c6f51573dc395bcdeed02aaeb96d88c403a13c726852ed70a8584"
 dependencies = [
  "async-trait",
  "futures",
@@ -12735,7 +12765,7 @@ dependencies = [
  "arrayvec 0.7.6",
  "curve25519-dalek-ng",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "subtle-ng",
  "zeroize",
@@ -12753,7 +12783,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -13073,7 +13103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -13091,9 +13121,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -13228,8 +13258,8 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "ruzstd 0.4.0",
  "schnorrkel 0.10.2",
  "serde",
@@ -13283,8 +13313,8 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "ruzstd 0.5.0",
  "schnorrkel 0.11.4",
  "serde",
@@ -13326,8 +13356,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 0.3.11",
@@ -13362,8 +13392,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 1.0.1",
@@ -13389,7 +13419,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "ring 0.17.9",
  "rustc_version",
  "sha2 0.10.8",
@@ -13427,7 +13457,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1",
 ]
 
@@ -13443,7 +13473,7 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
@@ -13688,7 +13718,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.13.1",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1 0.28.2",
@@ -13954,7 +13984,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -14042,7 +14072,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -14064,7 +14094,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
@@ -14159,7 +14189,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core",
@@ -14319,9 +14349,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cce13bf3abbda42464069f92c21c8cd64eeb089b43cde3c3aca5f90cf485d7b"
+checksum = "49c313f08759d0b0185eb2f889b516aa6a694b31c1032e587eedf29fc98e46e0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14342,9 +14372,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07e7020a321d74513c3d6e4015008de56e2a362758fd9615f6837b29b01a9ee"
+checksum = "dc0d0e7f1456b35413a910b3198d72eff2276ecd9d64b51288a0da44e82084d9"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14480,9 +14510,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0123f06e631f1a9c810de97bcedbe69cc73a56558ce1f1538b673ab44296b5d5"
+checksum = "f2a5de1ac5f3e5855ec75d21a892c9e5c0aac8e12f565e5b35bed4766e282836"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -14516,9 +14546,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ead3dbe5d0876c62113829582047afda5332a420fbbd8bc50399b925304f3"
+checksum = "5e9bc76e1b6dd94de67b127f154b161517007d562f2c752ade9edec0ec0e8f22"
 dependencies = [
  "jsonrpsee 0.24.8",
  "parity-scale-codec",
@@ -15096,16 +15126,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.1",
  "tungstenite",
 ]
 
@@ -15345,7 +15376,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
  "thiserror 1.0.69",
@@ -15371,7 +15402,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "thiserror 1.0.69",
  "tinyvec",
@@ -15392,7 +15423,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -15415,20 +15446,20 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.12",
+ "http 1.2.0",
  "httparse",
  "log",
- "rand",
- "rustls 0.21.12",
+ "rand 0.9.0",
+ "rustls 0.23.23",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "url",
  "utf-8",
 ]
@@ -15447,7 +15478,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -15656,9 +15687,9 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
  "thiserror 1.0.69",
@@ -16114,7 +16145,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -16139,6 +16170,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -16171,9 +16212,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "20.0.1"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171555c79be470f4ae58bb7e77f9ad0386fb527068c826fc529603263c4ac276"
+checksum = "ba014b88a6880dbc07f53c75cd0b5287e40972c84957f73e1bf22a1d2e824050"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -16652,7 +16693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
@@ -16676,18 +16717,18 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs 0.7.0",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry 0.7.1",
+ "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -16744,8 +16785,24 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]
@@ -16794,7 +16851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -16802,6 +16868,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,18 +39,18 @@ parachain-template-runtime = { path = "./runtime" }
 
 # Substrate
 frame-benchmarking = { version = "39.0.0", default-features = false }
-frame-benchmarking-cli = "45.0.0"
+frame-benchmarking-cli = "46.0.0"
 frame-executive = { version = "39.0.0", default-features = false }
 frame-support = { version = "39.0.0", default-features = false }
-frame-support-procedural = { version = "31.0.0", default-features = false }
-frame-system = { version = "39.0.0", default-features = false }
+frame-support-procedural = { version = "31.0.1", default-features = false }
+frame-system = { version = "39.1.0", default-features = false }
 frame-system-benchmarking = { version = "39.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "35.0.0", default-features = false }
 frame-try-runtime = { version = "0.45.0", default-features = false }
 frame-metadata-hash-extension = { version = "0.7.0", default-features = false }
 pallet-aura = { version = "38.0.0", default-features = false }
 pallet-authorship = { version = "39.0.0", default-features = false }
-pallet-balances = { version = "40.0.0", default-features = false }
+pallet-balances = { version = "40.0.1", default-features = false }
 pallet-message-queue = { version = "42.0.0", default-features = false }
 pallet-session = { version = "39.0.0", default-features = false }
 pallet-sudo = { version = "39.0.0", default-features = false }
@@ -59,22 +59,22 @@ pallet-transaction-payment = { version = "39.0.0", default-features = false }
 pallet-transaction-payment-rpc = "42.0.0"
 pallet-transaction-payment-rpc-runtime-api = { version = "39.0.0", default-features = false }
 prometheus-endpoint = { version = "0.17.1", default-features = false, package = "substrate-prometheus-endpoint" }
-sc-basic-authorship = "0.47.0"
-sc-chain-spec = "40.0.0"
-sc-cli = "0.49.0"
+sc-basic-authorship = "0.48.0"
+sc-chain-spec = "41.0.0"
+sc-cli = "0.50.0"
 sc-client-api = "38.0.0"
-sc-offchain = "42.0.0"
-sc-consensus = "0.46.0"
+sc-offchain = "43.0.0"
+sc-consensus = "0.47.0"
 sc-executor = "0.41.0"
-sc-network = "0.47.0"
-sc-network-sync = "0.46.0"
-sc-rpc = "42.0.0"
-sc-service = "0.48.0"
-sc-sysinfo = "40.0.0"
-sc-telemetry = "27.0.0"
+sc-network = "0.48.2"
+sc-network-sync = "0.47.0"
+sc-rpc = "43.0.0"
+sc-service = "0.49.0"
+sc-sysinfo = "41.0.0"
+sc-telemetry = "28.0.0"
 sc-tracing = "38.0.0"
-sc-transaction-pool = "38.0.0"
-sc-transaction-pool-api = "38.0.0"
+sc-transaction-pool = "38.1.0"
+sc-transaction-pool-api = "38.1.0"
 sp-api = { version = "35.0.0", default-features = false }
 sp-block-builder = { version = "35.0.0", default-features = false }
 sp-blockchain = "38.0.0"
@@ -86,48 +86,48 @@ sp-inherents = { version = "35.0.0", default-features = false }
 sp-keyring = { version = "40.0.0", default-features = false }
 sp-keystore = "0.41.0"
 sp-offchain = { version = "35.0.0", default-features = false }
-sp-runtime = { version = "40.0.0", default-features = false }
+sp-runtime = { version = "40.1.0", default-features = false }
 sp-session = { version = "37.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-timestamp = "35.0.0"
 sp-transaction-pool = { version = "35.0.0", default-features = false }
 sp-version = { version = "38.0.0", default-features = false }
-substrate-frame-rpc-system = "41.0.0"
+substrate-frame-rpc-system = "42.0.0"
 
 # Contracts
 pallet-contracts = { version = "39.0.0", default-features = false }
 
 # Revive
-pallet-revive = { version = "0.4.0", default-features = false }
+pallet-revive = { version = "0.3.1", default-features = false }
 
 # Polkadot
 pallet-xcm = { version = "18.0.0", default-features = false }
-polkadot-cli = "21.0.0"
+polkadot-cli = "22.0.1"
 polkadot-parachain-primitives = { version = "15.0.0", default-features = false }
 polkadot-primitives = "17.0.0"
 polkadot-runtime-common = { version = "18.0.0", default-features = false }
-xcm = { version = "15.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "18.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "18.0.0", package = "staging-xcm-executor", default-features = false }
+xcm = { version = "15.0.1", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "18.0.1", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "18.0.1", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = "0.20.0"
-cumulus-client-collator = "0.20.0"
-cumulus-client-consensus-aura = "0.20.0"
-cumulus-client-consensus-common = "0.20.0"
+cumulus-client-cli = "0.21.1"
+cumulus-client-collator = "0.21.0"
+cumulus-client-consensus-aura = "0.21.0"
+cumulus-client-consensus-common = "0.21.0"
 cumulus-client-consensus-proposer = "0.17.0"
-cumulus-client-service = "0.21.0"
+cumulus-client-service = "0.22.0"
 cumulus-pallet-aura-ext = { version = "0.18.0", default-features = false }
 cumulus-pallet-parachain-system = { version = "0.18.0", default-features = false }
 cumulus-pallet-session-benchmarking = { version = "20.0.0", default-features = false }
 cumulus-pallet-xcm = { version = "0.18.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.18.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.18.1", default-features = false }
 cumulus-primitives-aura = { version = "0.16.0", default-features = false }
 cumulus-primitives-core = { version = "0.17.0", default-features = false }
 cumulus-primitives-parachain-inherent = "0.17.0"
 cumulus-primitives-storage-weight-reclaim = { version = "9.0.0", default-features = false }
 cumulus-primitives-utility = { version = "0.18.0", default-features = false }
-cumulus-relay-chain-interface = "0.20.0"
+cumulus-relay-chain-interface = "0.21.0"
 pallet-collator-selection = { version = "20.0.0", default-features = false }
 parachains-common = { version = "19.0.0", default-features = false }
 parachain-info = { version = "0.18.0", package = "staging-parachain-info", default-features = false }


### PR DESCRIPTION
Just ran `psvm -v stable2412-2` and then `cargo b -r` was successful.

[sc-1937]